### PR TITLE
Try more user-friendly param setup

### DIFF
--- a/docs/examples/sans2d.ipynb
+++ b/docs/examples/sans2d.ipynb
@@ -43,39 +43,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc2fffe1-a694-43b7-9234-e31da42d6df3",
-   "metadata": {
-    "tags": []
-   },
+   "id": "1468523e",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "params = {}\n",
-    "params[NeXusMonitorName[Incident]] = 'monitor2'\n",
-    "params[NeXusMonitorName[Transmission]] = 'monitor4'\n",
-    "\n",
-    "band = sc.linspace('wavelength', 2.0, 16.0, num=2, unit='angstrom')\n",
-    "params[WavelengthBands] = band\n",
-    "params[WavelengthBins] = sc.linspace(\n",
-    "    'wavelength', start=band[0], stop=band[-1], num=141\n",
-    ")\n",
-    "\n",
-    "mask_interval = sc.array(dims=['wavelength'], values=[2.21, 2.59], unit='angstrom')\n",
-    "params[WavelengthMask] = sc.DataArray(\n",
-    "    sc.array(dims=['wavelength'], values=[True]),\n",
-    "    coords={'wavelength': mask_interval},\n",
-    ")\n",
-    "\n",
-    "params[QBins] = sc.linspace(dim='Q', start=0.01, stop=0.6, num=141, unit='1/angstrom')\n",
+    "wav_bins = sc.linspace('wavelength', start=2.0, stop=16.0, num=141, unit='angstrom')\n",
+    "q_bins = sc.linspace('Q', start=0.01, stop=0.6, num=141, unit='1/angstrom')\n",
+    "params = sans.params.setup(wavelength_bins=wav_bins, q_bins=q_bins)\n",
+    "params.update(sans.params.sans2d())\n",
     "params[Filename[BackgroundRun]] = 'SANS2D00063159.hdf5'\n",
     "params[Filename[SampleRun]] = 'SANS2D00063114.hdf5'\n",
     "params[Filename[DirectRun]] = 'SANS2D00063091.hdf5'\n",
     "params[DirectBeamFilename] = 'DIRECT_SANS2D_REAR_34327_4m_8mm_16Feb16.hdf5'\n",
-    "params[BeamCenter] = sc.vector(value=[0.0945643, -0.082074, 0.0], unit='m')\n",
-    "params[NonBackgroundWavelengthRange] = sc.array(\n",
-    "    dims=['wavelength'], values=[0.7, 17.1], unit='angstrom'\n",
-    ")\n",
-    "params[CorrectForGravity] = True\n",
-    "params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound"
+    "params[BeamCenter] = sc.vector(value=[0.0945643, -0.082074, 0.0], unit='m')"
    ]
   },
   {

--- a/src/esssans/__init__.py
+++ b/src/esssans/__init__.py
@@ -9,6 +9,6 @@ try:
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 
-from . import common, conversions, i_of_q, normalization, sans2d
+from . import common, conversions, i_of_q, normalization, params, sans2d
 
 providers = conversions.providers + i_of_q.providers + normalization.providers

--- a/src/esssans/params.py
+++ b/src/esssans/params.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+import scipp as sc
+
+from .types import (
+    CorrectForGravity,
+    Incident,
+    NeXusMonitorName,
+    NonBackgroundWavelengthRange,
+    QBins,
+    Transmission,
+    UncertaintyBroadcastMode,
+    WavelengthBands,
+    WavelengthBins,
+    WavelengthMask,
+)
+
+
+def sans2d() -> dict:
+    params = {}
+    params[NeXusMonitorName[Incident]] = 'monitor2'
+    params[NeXusMonitorName[Transmission]] = 'monitor4'
+    # Is this always the same?
+    mask_interval = sc.array(dims=['wavelength'], values=[2.21, 2.59], unit='angstrom')
+    params[WavelengthMask] = sc.DataArray(
+        sc.array(dims=['wavelength'], values=[True]),
+        coords={'wavelength': mask_interval},
+    )
+    # Is this always the same?
+    params[NonBackgroundWavelengthRange] = sc.array(
+        dims=['wavelength'], values=[0.7, 17.1], unit='angstrom'
+    )
+    return params
+
+
+def base_params() -> dict:
+    params = {}
+    params[CorrectForGravity] = False
+    params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound
+    return params
+
+
+def setup(*, wavelength_bins: sc.Variable, q_bins: sc.Variable) -> dict:
+    params = base_params()
+    params[WavelengthBands] = WavelengthBands(
+        sc.concat([wavelength_bins[0], wavelength_bins[-1]], wavelength_bins.dim)
+    )
+    params[WavelengthBins] = WavelengthBins(wavelength_bins)
+    params[QBins] = QBins(q_bins)
+    return params


### PR DESCRIPTION
Not intended for merging, this is meant for gathering feedback. Param setup now looks like this:

```python
wav_bins = sc.linspace('wavelength', start=2.0, stop=16.0, num=141, unit='angstrom')
q_bins = sc.linspace('Q', start=0.01, stop=0.6, num=141, unit='1/angstrom')
params = sans.params.setup(wavelength_bins=wav_bins, q_bins=q_bins)
params.update(sans.params.sans2d())
params[Filename[BackgroundRun]] = 'SANS2D00063159.hdf5'
params[Filename[SampleRun]] = 'SANS2D00063114.hdf5'
params[Filename[DirectRun]] = 'SANS2D00063091.hdf5'
params[DirectBeamFilename] = 'DIRECT_SANS2D_REAR_34327_4m_8mm_16Feb16.hdf5'
params[BeamCenter] = sc.vector(value=[0.0945643, -0.082074, 0.0], unit='m')
```

This hides more of what is going on, which can be good as well as bad. In particular:

- Default setup includes gravity option and uncertianty-broadcast-mode
- Sans2d setup includes monitor names (makes sense to hide) but also wavelength-mask and monitor-background-range.