### PR TITLE
Fix application of beam center

### DIFF
--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -9,37 +9,37 @@ import scipp as sc
 
 from .conversions import (
     ElasticCoordTransformGraph,
-    to_Q,
-    mask_wavelength,
     calibrate_positions,
     detector_to_wavelength,
+    mask_wavelength,
+    to_Q,
 )
 from .i_of_q import merge_spectra
 from .logging import get_logger
 from .normalization import (
-    normalize,
     iofq_denominator,
+    normalize,
     solid_angle_rectangular_approximation,
 )
 from .types import (
     BeamCenter,
     Clean,
+    CleanDirectBeam,
     CleanMasked,
+    CleanMonitor,
     Denominator,
+    DirectRun,
+    Incident,
     IofQ,
     MaskedData,
     Numerator,
     QBins,
     SampleRun,
+    SolidAngle,
+    Transmission,
+    UncertaintyBroadcastMode,
     WavelengthBands,
     WavelengthBins,
-    CleanMonitor,
-    Transmission,
-    DirectRun,
-    Incident,
-    SolidAngle,
-    CleanDirectBeam,
-    UncertaintyBroadcastMode,
 )
 
 

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -127,8 +127,6 @@ def iofq_in_quadrants(
     params[WavelengthBands] = wavelength_range
     params[QBins] = q_bins
     params[ElasticCoordTransformGraph] = graph
-    # TODO must use sel if direct bema added pixel dim here
-    params[NormWavelengthTerm[SampleRun]] = norm
     params[BeamCenter] = center
 
     out = {}
@@ -136,6 +134,10 @@ def iofq_in_quadrants(
         # Select pixels based on phi
         sel = (phi >= phi_bins[i]) & (phi < phi_bins[i + 1])
         params[MaskedData[SampleRun]] = data[sel]
+        if norm.dims == ('wavelength',):
+            params[NormWavelengthTerm[SampleRun]] = norm
+        else:
+            params[NormWavelengthTerm[SampleRun]] = norm[sel]
         pipeline = sciline.Pipeline(providers, params=params)
         out[quad] = pipeline.compute(IofQ[SampleRun])
     return out

--- a/src/esssans/conversions.py
+++ b/src/esssans/conversions.py
@@ -10,13 +10,13 @@ from scippneutron.conversion.graph import beamline, tof
 from .common import mask_range
 from .types import (
     BeamCenter,
+    CalibratedMaskedData,
     Clean,
     CleanMasked,
     CleanQ,
     CorrectForGravity,
     IofQPart,
     MaskedData,
-    CalibratedMaskedData,
     MonitorType,
     Numerator,
     RawMonitor,

--- a/src/esssans/normalization.py
+++ b/src/esssans/normalization.py
@@ -126,9 +126,8 @@ def iofq_norm_wavelength_term(
 
     Because the multiplication between the wavelength dependent terms (monitor counts)
     and the pixel dependent term (solid angle) consists of a broadcast operation which
-    would introduce correlations, we strip the data of variances.
-    It is the responsibility of the user to ensure that the variances are small enough
-    that they can be ignored. See more details in Heybrock et al. (2023).
+    would introduce correlations, variances are dropped or replaced by an upper-bound
+    estimation, depending on the configured mode.
 
     Parameters
     ----------
@@ -185,9 +184,9 @@ def iofq_denominator(
 
     Because the multiplication between the wavelength dependent terms (monitor counts)
     and the pixel dependent term (solid angle) consists of a broadcast operation which
-    would introduce correlations, we strip the data of variances.
-    It is the responsibility of the user to ensure that the variances are small enough
-    that they can be ignored. See more details in Heybrock et al. (2023).
+    would introduce correlations, variances are dropped or replaced by an upper-bound
+    estimation, depending on the configured mode.
+
 
     Parameters
     ----------

--- a/src/esssans/normalization.py
+++ b/src/esssans/normalization.py
@@ -161,8 +161,8 @@ def iofq_norm_wavelength_term(
     # solid_angle (pixel-dependent) and monitors (wavelength-dependent) will fail.
     # The direct beam may also be pixel-dependent. In this case we need to drop
     # variances of the other term already before multiplying by solid_angle.
-    broadcast = _broadcasters[uncertainties]
     if direct_beam is not None:
+        broadcast = _broadcasters[uncertainties]
         denominator = direct_beam * broadcast(denominator, sizes=direct_beam.sizes)
     # Convert wavelength coordinate to midpoints for future histogramming
     # if wavelength_to_midpoints:

--- a/src/esssans/normalization.py
+++ b/src/esssans/normalization.py
@@ -16,7 +16,7 @@ from .types import (
     DirectRun,
     Incident,
     IofQ,
-    MaskedData,
+    CalibratedMaskedData,
     Numerator,
     RunType,
     SampleRun,
@@ -32,7 +32,7 @@ from .uncertainty import (
 
 
 def solid_angle_rectangular_approximation(
-    data: MaskedData[RunType],
+    data: CalibratedMaskedData[RunType],
 ) -> SolidAngle[RunType]:
     """
     Solid angle computed from rectangular pixels with a 'width' and a 'height'.

--- a/src/esssans/sans2d.py
+++ b/src/esssans/sans2d.py
@@ -81,8 +81,8 @@ def mask_detectors(
 
 
 providers = [
-    pooch_load,
     pooch_load_direct_beam,
+    pooch_load,
     get_monitor,
     detector_edge_mask,
     sample_holder_mask,

--- a/src/esssans/types.py
+++ b/src/esssans/types.py
@@ -117,6 +117,10 @@ class CalibratedMaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Raw data with pixel-specific masks applied and calibrated pixel positions"""
 
 
+class NormWavelengthTerm(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    pass
+
+
 class Clean(sciline.ScopeTwoParams[RunType, IofQPart, sc.DataArray], sc.DataArray):
     """
     Prerequisite for IofQ numerator or denominator.
@@ -125,8 +129,6 @@ class Clean(sciline.ScopeTwoParams[RunType, IofQPart, sc.DataArray], sc.DataArra
     or the respective normalization terms computed from the respective solid angle,
     direct beam, and monitors.
     """
-
-    value: sc.DataArray
 
 
 class CleanMasked(

--- a/src/esssans/types.py
+++ b/src/esssans/types.py
@@ -113,6 +113,10 @@ class MaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Raw data with pixel-specific masks applied"""
 
 
+class CalibratedMaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """Raw data with pixel-specific masks applied and calibrated pixel positions"""
+
+
 class Clean(sciline.ScopeTwoParams[RunType, IofQPart, sc.DataArray], sc.DataArray):
     """
     Prerequisite for IofQ numerator or denominator.

--- a/src/esssans/types.py
+++ b/src/esssans/types.py
@@ -118,7 +118,7 @@ class CalibratedMaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
 
 
 class NormWavelengthTerm(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
-    pass
+    """Normalization term (numerator) for IofQ before scaling with solid-angle."""
 
 
 class Clean(sciline.ScopeTwoParams[RunType, IofQPart, sc.DataArray], sc.DataArray):


### PR DESCRIPTION
Fixes #13.

Also re-compute solid angle during iteration. This change resulted in a ~3mm difference in the result for the beam center, compared to the pre-Sciline implementation.