### PR TITLE
Fix center-of-mass estimation of beam center

### DIFF
--- a/docs/examples/sans2d.ipynb
+++ b/docs/examples/sans2d.ipynb
@@ -70,7 +70,6 @@
     "params[Filename[SampleRun]] = 'SANS2D00063114.hdf5'\n",
     "params[Filename[DirectRun]] = 'SANS2D00063091.hdf5'\n",
     "params[DirectBeamFilename] = 'DIRECT_SANS2D_REAR_34327_4m_8mm_16Feb16.hdf5'\n",
-    "params[BeamCenter] = sc.vector(value=[0.0945643, -0.082074, 0.0], unit='m')\n",
     "params[NonBackgroundWavelengthRange] = sc.array(\n",
     "    dims=['wavelength'], values=[0.7, 17.1], unit='angstrom'\n",
     ")\n",

--- a/src/esssans/__init__.py
+++ b/src/esssans/__init__.py
@@ -12,3 +12,5 @@ except importlib.metadata.PackageNotFoundError:
 from . import beam_center_finder, common, conversions, i_of_q, normalization, sans2d
 
 providers = conversions.providers + i_of_q.providers + normalization.providers
+# Default to fast but potentially inaccurate beam center finder
+providers.append(beam_center_finder.beam_center_from_center_of_mass)

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -53,8 +53,9 @@ def beam_center_from_center_of_mass(
     The center-of-mass is simply the weighted mean of the positions.
     Areas with low counts are excluded from the center of mass calculation, as they
     typically fall into asymmetric regions of the detector panel and would thus lead
-    to a biased result. The Z component is set to zero, as the detector panel is
-    assumed to lie in the X-Y plane.
+    to a biased result. The beam is assumed to be roughly aligned with the Z axis.
+    The returned beam center is the component normal to the bema direction, projected
+    onto the X-Y plane.
 
     Parameters
     ----------

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -54,7 +54,7 @@ def beam_center_from_center_of_mass(
     Areas with low counts are excluded from the center of mass calculation, as they
     typically fall into asymmetric regions of the detector panel and would thus lead
     to a biased result. The beam is assumed to be roughly aligned with the Z axis.
-    The returned beam center is the component normal to the bema direction, projected
+    The returned beam center is the component normal to the beam direction, projected
     onto the X-Y plane.
 
     Parameters

--- a/tests/sans2d_reduction_test.py
+++ b/tests/sans2d_reduction_test.py
@@ -57,7 +57,6 @@ def make_params() -> dict:
     params[Filename[SampleRun]] = 'SANS2D00063114.hdf5'
     params[Filename[DirectRun]] = 'SANS2D00063091.hdf5'
     params[DirectBeamFilename] = 'DIRECT_SANS2D_REAR_34327_4m_8mm_16Feb16.hdf5'
-    params[BeamCenter] = sc.vector(value=[0.0945643, -0.082074, 0.0], unit='m')
     params[NonBackgroundWavelengthRange] = sc.array(
         dims=['wavelength'], values=[0.7, 17.1], unit='angstrom'
     )
@@ -162,15 +161,29 @@ def test_pixel_dependent_direct_beam_is_supported(uncertainties):
     assert result.dims == ('Q',)
 
 
+def test_beam_center_from_center_of_mass_is_close_to_verified_result():
+    params = make_params()
+    providers = sans2d_providers()
+    pipeline = sciline.Pipeline(providers, params=params)
+    center = pipeline.compute(BeamCenter)
+    # This is the result we got with the pre-sciline implementation, using the full IofQ
+    # calculation. The difference is about 5 mm in X or Y, probably due to a bias
+    # introduced by the sample holder, which the center-of-mass approach cannot ignore.
+    center_pre_sciline_raw_solid_angle = sc.vector([0.0945643, -0.082074, 0], unit='m')
+    assert sc.allclose(
+        center, center_pre_sciline_raw_solid_angle, atol=sc.scalar(5e-3, unit='m')
+    )
+
+
 def test_beam_center_finder_without_direct_beam_reproduces_verified_result():
     params = make_params()
     params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(
         'Q', 0.02, 0.3, 71, unit='1/angstrom'
     )
-    del params[BeamCenter]
     del params[DirectBeamFilename]
     providers = sans2d_providers()
-    providers.append(sans.beam_center_finder.beam_center)
+    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
+    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
     center = pipeline.compute(BeamCenter)
     # This is the result we got with the pre-sciline implementation
@@ -187,9 +200,9 @@ def test_beam_center_finder_works_with_direct_beam():
     params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(
         'Q', 0.02, 0.3, 71, unit='1/angstrom'
     )
-    del params[BeamCenter]
     providers = sans2d_providers()
-    providers.append(sans.beam_center_finder.beam_center)
+    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
+    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
     center = pipeline.compute(BeamCenter)  # (0.0951122, -0.079375, 0)
     center_no_direct_beam = sc.vector([0.0945643, -0.082074, 0], unit='m')
@@ -202,9 +215,9 @@ def test_beam_center_finder_works_with_pixel_dependent_direct_beam():
     params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(
         'Q', 0.02, 0.3, 71, unit='1/angstrom'
     )
-    del params[BeamCenter]
     providers = sans2d_providers()
-    providers.append(sans.beam_center_finder.beam_center)
+    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
+    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
     center_pixel_independent_direct_beam = pipeline.compute(BeamCenter)
 
@@ -218,7 +231,8 @@ def test_beam_center_finder_works_with_pixel_dependent_direct_beam():
     params[DirectBeam] = direct_beam
     # Hack to remove direct-beam provider, until Sciline API improved
     providers = sans.providers + sans.sans2d.providers[1:]
-    providers.append(sans.beam_center_finder.beam_center)
+    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
+    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
 
     center = pipeline.compute(BeamCenter)


### PR DESCRIPTION
- Fix ignored masks
- Make approach viable, by ignoring low-count regions that lead to asymmetric cutoffs, when the scattering patterns touches the edges of the detector panel.

I have enabled this as a default in the workflow, since it takes less than a second (as opposed to 20 seconds).