### PR TITLE
Use transmission fraction in normalization

### DIFF
--- a/docs/examples/sans2d.ipynb
+++ b/docs/examples/sans2d.ipynb
@@ -59,6 +59,8 @@
     "    'wavelength', start=band[0], stop=band[-1], num=141\n",
     ")\n",
     "\n",
+    "params[MaskingCountsThreshold] = sc.scalar(100, unit='counts')\n",
+    "\n",
     "mask_interval = sc.array(dims=['wavelength'], values=[2.21, 2.59], unit='angstrom')\n",
     "params[WavelengthMask] = sc.DataArray(\n",
     "    sc.array(dims=['wavelength'], values=[True]),\n",
@@ -67,7 +69,9 @@
     "\n",
     "params[QBins] = sc.linspace(dim='Q', start=0.01, stop=0.6, num=141, unit='1/angstrom')\n",
     "params[Filename[BackgroundRun]] = 'SANS2D00063159.hdf5'\n",
+    "params[Filename[BackgroundTransmissionRun]] = params[Filename[BackgroundRun]]\n",
     "params[Filename[SampleRun]] = 'SANS2D00063114.hdf5'\n",
+    "params[Filename[SampleTransmissionRun]] = params[Filename[SampleRun]]\n",
     "params[Filename[DirectRun]] = 'SANS2D00063091.hdf5'\n",
     "params[DirectBeamFilename] = 'DIRECT_SANS2D_REAR_34327_4m_8mm_16Feb16.hdf5'\n",
     "params[NonBackgroundWavelengthRange] = sc.array(\n",
@@ -289,8 +293,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -26,9 +26,11 @@ from .types import (
     BeamCenter,
     IofQ,
     MaskedData,
-    NormWavelengthTerm,
+    # NormWavelengthTerm,
     QBins,
     SampleRun,
+    SampleTransmissionRun,
+    TransmissionFractionTimesDirectBeam,
     UncertaintyBroadcastMode,
     WavelengthBands,
     WavelengthBins,
@@ -175,8 +177,9 @@ def _iofq_in_quadrants(
     for i, quad in enumerate(quadrants):
         # Select pixels based on phi
         sel = (phi >= phi_bins[i]) & (phi < phi_bins[i + 1])
+        # TODO: we need detector data normalized by monitor counts here
         params[MaskedData[SampleRun]] = data[sel]
-        params[NormWavelengthTerm[SampleRun]] = (
+        params[TransmissionFractionTimesDirectBeam[SampleTransmissionRun]] = (
             norm if norm.dims == ('wavelength',) else norm[sel]
         )
         pipeline = sciline.Pipeline(providers, params=params)
@@ -264,7 +267,7 @@ def beam_center_from_iofq(
     data: MaskedData[SampleRun],
     graph: ElasticCoordTransformGraph,
     wavelength_bins: WavelengthBins,
-    norm: NormWavelengthTerm[SampleRun],
+    norm: TransmissionFractionTimesDirectBeam[SampleTransmissionRun],
     q_bins: BeamCenterFinderQBins,
     minimizer: Optional[BeamCenterFinderMinimizer],
     tolerance: Optional[BeamCenterFinderTolerance],

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -18,8 +18,7 @@ from .conversions import (
 from .i_of_q import merge_spectra
 from .logging import get_logger
 from .normalization import (
-    iofq_denominator_background,
-    iofq_denominator_sample,
+    iofq_denominator,
     normalize,
     solid_angle_rectangular_approximation,
 )
@@ -27,11 +26,10 @@ from .types import (
     BeamCenter,
     IofQ,
     MaskedData,
-    # NormWavelengthTerm,
+    NormWavelengthTerm,
     QBins,
     SampleRun,
     SampleTransmissionRun,
-    TransmissionFractionTimesDirectBeam,
     UncertaintyBroadcastMode,
     WavelengthBands,
     WavelengthBins,
@@ -161,8 +159,7 @@ def _iofq_in_quadrants(
         to_Q,
         merge_spectra,
         normalize,
-        iofq_denominator_background,
-        iofq_denominator_sample,
+        iofq_denominator,
         mask_wavelength,
         detector_to_wavelength,
         calibrate_positions,
@@ -181,7 +178,7 @@ def _iofq_in_quadrants(
         sel = (phi >= phi_bins[i]) & (phi < phi_bins[i + 1])
         # TODO: we need detector data normalized by monitor counts here
         params[MaskedData[SampleRun]] = data[sel]
-        params[TransmissionFractionTimesDirectBeam[SampleTransmissionRun]] = (
+        params[NormWavelengthTerm[SampleRun]] = (
             norm if norm.dims == ('wavelength',) else norm[sel]
         )
         pipeline = sciline.Pipeline(providers, params=params)
@@ -269,7 +266,7 @@ def beam_center_from_iofq(
     data: MaskedData[SampleRun],
     graph: ElasticCoordTransformGraph,
     wavelength_bins: WavelengthBins,
-    norm: TransmissionFractionTimesDirectBeam[SampleTransmissionRun],
+    norm: NormWavelengthTerm[SampleRun],
     q_bins: BeamCenterFinderQBins,
     minimizer: Optional[BeamCenterFinderMinimizer],
     tolerance: Optional[BeamCenterFinderTolerance],

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -29,7 +29,6 @@ from .types import (
     NormWavelengthTerm,
     QBins,
     SampleRun,
-    SampleTransmissionRun,
     UncertaintyBroadcastMode,
     WavelengthBands,
     WavelengthBins,

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -18,7 +18,8 @@ from .conversions import (
 from .i_of_q import merge_spectra
 from .logging import get_logger
 from .normalization import (
-    iofq_denominator,
+    iofq_denominator_background,
+    iofq_denominator_sample,
     normalize,
     solid_angle_rectangular_approximation,
 )
@@ -160,7 +161,8 @@ def _iofq_in_quadrants(
         to_Q,
         merge_spectra,
         normalize,
-        iofq_denominator,
+        iofq_denominator_background,
+        iofq_denominator_sample,
         mask_wavelength,
         detector_to_wavelength,
         calibrate_positions,

--- a/src/esssans/conversions.py
+++ b/src/esssans/conversions.py
@@ -151,7 +151,7 @@ def sans_elastic(gravity: Optional[CorrectForGravity]) -> ElasticCoordTransformG
     gravity:
         Take into account the bending of the neutron flight paths from the
         Earth's gravitational field if ``True``.
-    """  # noqa: E501
+    """  # noqa: E501, W605
     graph = {**beamline.beamline(scatter=True), **tof.elastic_Q('tof')}
     if gravity:
         graph['two_theta'] = two_theta

--- a/src/esssans/conversions.py
+++ b/src/esssans/conversions.py
@@ -125,9 +125,31 @@ MonitorCoordTransformGraph = NewType('MonitorCoordTransformGraph', dict)
 def sans_elastic(gravity: Optional[CorrectForGravity]) -> ElasticCoordTransformGraph:
     """
     Generate a coordinate transformation graph for SANS elastic scattering.
-    By default, the effects of gravity on the neutron flight paths are not included.
 
-    :param gravity: Take into account the bending of the neutron flight paths from the
+    It is based on classical conversions from ``tof`` and pixel ``position`` to
+    $\lambda$ (``wavelength``), $\theta$ (``theta``) and $Q$ (``Q``),
+    but can take into account the Earth's gravitational field, which bends the flight
+    path of the neutrons, to compute the scattering angle $\theta$.
+
+    The angle can be found using the following expression
+    (Seeger & Hjelm 1991,  J. Appl. Cryst., 24, 467-478):
+
+    $$\theta = \frac{1}{2}\sin^{-1}\left(\frac{\sqrt{ x^{2} + \left( y + \frac{g m_{\rm n}}{2 h^{2}} \lambda^{2} L_{2}^{2} \right)^{2} } }{L_{2}}\right)$$
+
+    where $x$ and $y$ are the spatial coordinates of the pixels in the horizontal and
+    vertical directions, respectively,
+    $m_{\rm n}$ is the neutron mass,
+    $L_{2}$ is the distance between the sample and a detector pixel,
+    $g$ is the acceleration due to gravity,
+    and $h$ is Planck's constant.
+
+    By default, the effects of gravity on the neutron flight paths are not included
+    (equivalent to $g=0$ in the expression above).
+
+    Parameters
+    ----------
+    gravity:
+        Take into account the bending of the neutron flight paths from the
         Earth's gravitational field if ``True``.
     """
     graph = {**beamline.beamline(scatter=True), **tof.elastic_Q('tof')}

--- a/src/esssans/conversions.py
+++ b/src/esssans/conversions.py
@@ -151,7 +151,7 @@ def sans_elastic(gravity: Optional[CorrectForGravity]) -> ElasticCoordTransformG
     gravity:
         Take into account the bending of the neutron flight paths from the
         Earth's gravitational field if ``True``.
-    """
+    """  # noqa: E501
     graph = {**beamline.beamline(scatter=True), **tof.elastic_Q('tof')}
     if gravity:
         graph['two_theta'] = two_theta

--- a/src/esssans/normalization.py
+++ b/src/esssans/normalization.py
@@ -129,10 +129,10 @@ _broadcasters = {
 
 
 def transmission_fraction_times_direct_beam(
-    transmission_fraction: TransmissionFraction,
+    transmission_fraction: TransmissionFraction[TransmissionRunType],
     direct_beam: Optional[CleanDirectBeam],
     uncertainties: UncertaintyBroadcastMode,
-) -> TransmissionFractionTimesDirectBeam[RunType]:
+) -> TransmissionFractionTimesDirectBeam[TransmissionRunType]:
     """
     Compute the wavelength-dependen contribution to the denominator term for the I(Q) normalization.
 
@@ -182,7 +182,7 @@ def transmission_fraction_times_direct_beam(
 
 def iofq_denominator(
     transmission_fraction_times_direct_beam: TransmissionFractionTimesDirectBeam[
-        RunType
+        TransmissionRunType
     ],
     solid_angle: SolidAngle[RunType],
     uncertainties: UncertaintyBroadcastMode,

--- a/src/esssans/sans2d.py
+++ b/src/esssans/sans2d.py
@@ -75,7 +75,6 @@ def get_monitor(
 def detector_edge_mask(
     sample: RawData[SampleRun],
 ) -> DetectorEdgeMask:
-    # sample = raw['data']
     mask_edges = (
         sc.abs(sample.coords['position'].fields.x) > sc.scalar(0.48, unit='m')
     ) | (sc.abs(sample.coords['position'].fields.y) > sc.scalar(0.45, unit='m'))

--- a/src/esssans/sans2d.py
+++ b/src/esssans/sans2d.py
@@ -10,6 +10,7 @@ import scipp as sc
 
 from .common import gravity_vector
 from .types import (
+    DataNormalizedByIncidentMonitor,
     DetectorEdgeMask,
     DirectBeam,
     DirectBeamFilename,
@@ -64,7 +65,9 @@ def get_monitor(
     return RawMonitor[RunType, MonitorType](mon)
 
 
-def detector_edge_mask(raw: RawData[SampleRun]) -> DetectorEdgeMask:
+def detector_edge_mask(
+    raw: DataNormalizedByIncidentMonitor[SampleRun],
+) -> DetectorEdgeMask:
     sample = raw['data']
     mask_edges = (
         sc.abs(sample.coords['position'].fields.x) > sc.scalar(0.48, unit='m')
@@ -72,7 +75,9 @@ def detector_edge_mask(raw: RawData[SampleRun]) -> DetectorEdgeMask:
     return DetectorEdgeMask(mask_edges)
 
 
-def sample_holder_mask(raw: RawData[SampleRun]) -> SampleHolderMask:
+def sample_holder_mask(
+    raw: DataNormalizedByIncidentMonitor[SampleRun],
+) -> SampleHolderMask:
     sample = raw['data']
     summed = sample.sum('tof')
     holder_mask = (
@@ -86,7 +91,7 @@ def sample_holder_mask(raw: RawData[SampleRun]) -> SampleHolderMask:
 
 
 def mask_detectors(
-    dg: RawData[RunType],
+    dg: DataNormalizedByIncidentMonitor[RunType],
     edge_mask: Optional[DetectorEdgeMask],
     holder_mask: Optional[SampleHolderMask],
 ) -> MaskedData[RunType]:

--- a/src/esssans/types.py
+++ b/src/esssans/types.py
@@ -128,6 +128,10 @@ class SolidAngle(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Solid angle of detector pixels seen from sample position"""
 
 
+class LoadedFileContents(sciline.Scope[RunType, sc.DataGroup], sc.DataGroup):
+    """The entire contents of the loaded filed"""
+
+
 class RawData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Raw data"""
 

--- a/src/esssans/types.py
+++ b/src/esssans/types.py
@@ -16,12 +16,31 @@ import scipp as sc
 # 1.1  Run types
 BackgroundRun = NewType('BackgroundRun', int)
 """Background run"""
+BackgroundTransmissionRun = NewType('BackgroundTransmissionRun', int)
+"""Background run with transmission monitor"""
 DirectRun = NewType('DirectRun', int)
 """Direct run"""
 SampleRun = NewType('SampleRun', int)
 """Sample run"""
-RunType = TypeVar('RunType', BackgroundRun, DirectRun, SampleRun)
-"""TypeVar used for specifying BackgroundRun, DirectRun or SampleRun"""
+SampleTransmissionRun = NewType('SampleTransmissionRun', int)
+"""Sample run with transmission monitor"""
+RunType = TypeVar(
+    'RunType',
+    BackgroundRun,
+    BackgroundTransmissionRun,
+    DirectRun,
+    SampleRun,
+    SampleTransmissionRun,
+)
+"""TypeVar used for specifying BackgroundRun, BackgroundTransmissionRun, DirectRun,
+SampleRun, or SampleTransmissionRun"""
+
+TransmissionRunType = TypeVar(
+    'TransmissionRunType',
+    BackgroundTransmissionRun,
+    SampleTransmissionRun,
+)
+"""TypeVar used for specifying BackgroundTransmissionRun or SampleTransmissionRun"""
 
 # 1.2  Monitor types
 Incident = NewType('Incident', int)
@@ -94,12 +113,11 @@ SampleHolderMask = NewType('SampleHolderMask', sc.Variable)
 DirectBeam = NewType('DirectBeam', sc.DataArray)
 """Direct beam"""
 
-TransmissionFraction = NewType('TransmissionFraction', sc.DataArray)
-"""
-Transmission fraction for inspection purposes.
 
-The IofQ computation does not use this, it uses the monitors directly.
-"""
+class TransmissionFraction(
+    sciline.Scope[TransmissionRunType, sc.DataArray], sc.DataArray
+):
+    """Transmission fraction"""
 
 
 CleanDirectBeam = NewType('CleanDirectBeam', sc.DataArray)
@@ -114,6 +132,12 @@ class RawData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Raw data"""
 
 
+class DataNormalizedByIncidentMonitor(
+    sciline.Scope[RunType, sc.DataArray], sc.DataArray
+):
+    """Data where raw counts have been normalized by the incident monitor counts"""
+
+
 class MaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Raw data with pixel-specific masks applied"""
 
@@ -122,7 +146,9 @@ class CalibratedMaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Raw data with pixel-specific masks applied and calibrated pixel positions"""
 
 
-class NormWavelengthTerm(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+class TransmissionFractionTimesDirectBeam(
+    sciline.Scope[TransmissionRunType, sc.DataArray], sc.DataArray
+):
     """Normalization term (numerator) for IofQ before scaling with solid-angle."""
 
 

--- a/src/esssans/types.py
+++ b/src/esssans/types.py
@@ -88,6 +88,11 @@ DirectBeamFilename = NewType('DirectBeamFilename', str)
 BeamCenter = NewType('BeamCenter', sc.Variable)
 """Beam center, may be set directly or computed using beam-center finder"""
 
+MaskingCountsThreshold = NewType('MaskingCountsThreshold', sc.Variable)
+"""Threshold below which detector pixels should be masked
+(low-counts on the edges of the detector panel, and the beam stop)"""
+
+
 WavelengthMask = NewType('WavelengthMask', sc.DataArray)
 """Optional wavelength mask"""
 
@@ -134,12 +139,6 @@ class LoadedFileContents(sciline.Scope[RunType, sc.DataGroup], sc.DataGroup):
 
 class RawData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Raw data"""
-
-
-class DataNormalizedByIncidentMonitor(
-    sciline.Scope[RunType, sc.DataArray], sc.DataArray
-):
-    """Data where raw counts have been normalized by the incident monitor counts"""
 
 
 class MaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):

--- a/src/esssans/types.py
+++ b/src/esssans/types.py
@@ -149,9 +149,7 @@ class CalibratedMaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Raw data with pixel-specific masks applied and calibrated pixel positions"""
 
 
-class TransmissionFractionTimesDirectBeam(
-    sciline.Scope[TransmissionRunType, sc.DataArray], sc.DataArray
-):
+class NormWavelengthTerm(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Normalization term (numerator) for IofQ before scaling with solid-angle."""
 
 

--- a/tests/sans2d_reduction_test.py
+++ b/tests/sans2d_reduction_test.py
@@ -10,6 +10,7 @@ import esssans as sans
 from esssans.types import (
     BackgroundRun,
     BackgroundSubtractedIofQ,
+    BackgroundTransmissionRun,
     BeamCenter,
     CorrectForGravity,
     DirectBeam,
@@ -18,11 +19,13 @@ from esssans.types import (
     Filename,
     Incident,
     IofQ,
+    MaskingCountsThreshold,
     NeXusMonitorName,
     NonBackgroundWavelengthRange,
     QBins,
     RawData,
     SampleRun,
+    SampleTransmissionRun,
     SolidAngle,
     Transmission,
     UncertaintyBroadcastMode,
@@ -49,12 +52,15 @@ def make_params() -> dict:
             )
         },
     )
+    params[MaskingCountsThreshold] = sc.scalar(100.0, unit='counts')
 
     params[QBins] = sc.linspace(
         dim='Q', start=0.01, stop=0.55, num=141, unit='1/angstrom'
     )
     params[Filename[BackgroundRun]] = 'SANS2D00063159.hdf5'
+    params[Filename[BackgroundTransmissionRun]] = params[Filename[BackgroundRun]]
     params[Filename[SampleRun]] = 'SANS2D00063114.hdf5'
+    params[Filename[SampleTransmissionRun]] = params[Filename[SampleRun]]
     params[Filename[DirectRun]] = 'SANS2D00063091.hdf5'
     params[DirectBeamFilename] = 'DIRECT_SANS2D_REAR_34327_4m_8mm_16Feb16.hdf5'
     params[NonBackgroundWavelengthRange] = sc.array(


### PR DESCRIPTION
It was realized in #31 that the incident monitor in the denominator is not necessarily from the same run at the incident monitor used in the transmission fraction (the transmission fraction is commonly computed from a 'transmission run').

We re-write the pipeline to take this into account.