### PR TITLE
Add the option to slice out straws/tubes/layers/pixels

### DIFF
--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -16,7 +16,7 @@ from .conversions import (
     mask_wavelength,
     to_Q,
 )
-from .i_of_q import merge_spectra
+from .i_of_q import dimension_slicing, merge_spectra
 from .logging import get_logger
 from .normalization import iofq_denominator, normalize, solid_angle
 from .types import (
@@ -173,6 +173,7 @@ def _iofq_in_quadrants(
         detector_to_wavelength,
         solid_angle,
         calibrate_positions,
+        dimension_slicing,
     ]
     params = {}
     params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound

--- a/src/esssans/conversions.py
+++ b/src/esssans/conversions.py
@@ -21,6 +21,7 @@ from .types import (
     Numerator,
     RawMonitor,
     RunType,
+    SlicedMaskedData,
     WavelengthMask,
     WavelengthMonitor,
 )
@@ -200,7 +201,7 @@ def calibrate_positions(
 # for RawData, MaskedData, ... no reason to restrict necessarily.
 # Would we be fine with just choosing on option, or will this get in the way for users?
 def detector_to_wavelength(
-    detector: CalibratedMaskedData[RunType],
+    detector: SlicedMaskedData[RunType],
     graph: ElasticCoordTransformGraph,
 ) -> CleanWavelength[RunType, Numerator]:
     return CleanWavelength[RunType, Numerator](

--- a/src/esssans/i_of_q.py
+++ b/src/esssans/i_of_q.py
@@ -11,10 +11,12 @@ from .logging import get_logger
 from .types import (
     BackgroundRun,
     BackgroundSubtractedIofQ,
+    CalibratedMaskedData,
     CleanDirectBeam,
     CleanMonitor,
     CleanQ,
     CleanSummedQ,
+    DetectorSlices,
     DimsToKeep,
     DirectBeam,
     IofQ,
@@ -24,6 +26,7 @@ from .types import (
     QBins,
     RunType,
     SampleRun,
+    SlicedMaskedData,
     UncertaintyBroadcastMode,
     WavelengthBands,
     WavelengthBins,
@@ -127,6 +130,20 @@ def resample_direct_beam(
         bounds_error=False,
     )
     return CleanDirectBeam(func(wavelength_bins, midpoints=True))
+
+
+def dimension_slicing(
+    data: CalibratedMaskedData[RunType],
+    slices: Optional[DetectorSlices] = None,
+) -> SlicedMaskedData[RunType]:
+    """
+    Slice out a subset of the detector tubes/straws/layers/pixels.
+    """
+    out = data
+    if slices is not None:
+        for dim, sl in slices.items():
+            out = out[dim, sl]
+    return SlicedMaskedData[RunType](out)
 
 
 def _process_wavelength_bands(
@@ -297,4 +314,5 @@ providers = (
     resample_direct_beam,
     merge_spectra,
     subtract_background,
+    dimension_slicing,
 )

--- a/src/esssans/i_of_q.py
+++ b/src/esssans/i_of_q.py
@@ -138,6 +138,9 @@ def dimension_slicing(
 ) -> SlicedMaskedData[RunType]:
     """
     Slice out a subset of the detector tubes/straws/layers/pixels.
+
+    Note that the slicing must be done after masking and computing the beam center, if
+    not the results will be different between sliced and non-sliced data.
     """
     out = data
     if slices is not None:

--- a/src/esssans/loki/io.py
+++ b/src/esssans/loki/io.py
@@ -29,7 +29,7 @@ from .general import default_parameters as params
 DETECTOR_BANK_RESHAPING = {
     params[NeXusDetectorName]: lambda x: x.fold(
         dim='detector_number', sizes=dict(layer=4, tube=32, straw=7, pixel=512)
-    ).flatten(dims=['tube', 'straw'], to='straw')
+    )
 }
 
 

--- a/src/esssans/normalization.py
+++ b/src/esssans/normalization.py
@@ -7,7 +7,6 @@ import scipp as sc
 from scipp.core import concepts
 
 from .types import (
-    CalibratedMaskedData,
     CleanDirectBeam,
     CleanMonitor,
     CleanSummedQ,
@@ -21,6 +20,7 @@ from .types import (
     NormWavelengthTerm,
     Numerator,
     RunType,
+    SlicedMaskedData,
     SolidAngle,
     Transmission,
     TransmissionFraction,
@@ -34,7 +34,7 @@ from .uncertainty import (
 
 
 def solid_angle(
-    data: CalibratedMaskedData[RunType],
+    data: SlicedMaskedData[RunType],
     pixel_shape: DetectorPixelShape[RunType],
     transform: LabFrameTransform[RunType],
 ) -> SolidAngle[RunType]:

--- a/src/esssans/types.py
+++ b/src/esssans/types.py
@@ -142,6 +142,10 @@ BeamStopPosition = NewType('BeamStopPosition', sc.Variable)
 BeamStopRadius = NewType('BeamStopRadius', sc.Variable)
 """Radius of the beam stop"""
 
+DetectorSlices = NewType('DetectorSlices', dict)
+"""Dictionary of slices that will be applied to the detector data for selecting only
+certain tubes/straws/layers/pixels."""
+
 # 3  Workflow (intermediate) results
 
 
@@ -192,6 +196,10 @@ class MaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
 
 class CalibratedMaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
     """Raw data with pixel-specific masks applied and calibrated pixel positions"""
+
+
+class SlicedMaskedData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """Data that has potentially had some tubes/straws/layers/pixels sliced out"""
 
 
 class NormWavelengthTerm(sciline.Scope[RunType, sc.DataArray], sc.DataArray):


### PR DESCRIPTION
A request from users: while playing around with the direct beam iterations, it would be nice to be able to just run it on a single layer/tube etc to speed up development.

This PR adds the option to slice out the data at the correct point in the workflow in a way that retains identical results.