### PR TITLE
Very fast direct beam iteration

### DIFF
--- a/src/esssans/direct_beam.py
+++ b/src/esssans/direct_beam.py
@@ -127,9 +127,7 @@ def direct_beam(pipeline: Pipeline, I0: sc.Variable, niter: int = 5) -> List[dic
 
     results = []
 
-    for it in range(niter):
-        print("Iteration", it)
-
+    for _it in range(niter):
         # The first time we compute I(Q), the direct beam function is not in the
         # parameters, nor given by any providers, so it will be considered flat.
         # TODO: Should we have a check that DirectBeam cannot be computed from the

--- a/src/esssans/direct_beam.py
+++ b/src/esssans/direct_beam.py
@@ -152,7 +152,7 @@ def direct_beam(pipeline: Pipeline, I0: sc.Variable, niter: int = 5) -> List[dic
             I0=I0,
         )
 
-        # Scale denominator terms that where initially computed without direct beam
+        # Scale denominator terms that were initially computed without direct beam
         # with the current direct beam function.
         db = resample_direct_beam(
             direct_beam=direct_beam_function,

--- a/src/esssans/direct_beam.py
+++ b/src/esssans/direct_beam.py
@@ -7,18 +7,17 @@ import numpy as np
 import scipp as sc
 from sciline import Pipeline
 
+from .i_of_q import resample_direct_beam
 from .types import (
     BackgroundRun,
     BackgroundSubtractedIofQ,
-    CleanMonitor,
     CleanSummedQ,
-    DirectBeam,
-    Incident,
+    Denominator,
     Numerator,
     ProcessedWavelengthBands,
     SampleRun,
-    SolidAngle,
-    TransmissionFraction,
+    WavelengthBands,
+    WavelengthBins,
 )
 
 
@@ -99,33 +98,26 @@ def direct_beam(pipeline: Pipeline, I0: sc.Variable, niter: int = 5) -> List[dic
     direct_beam_function = None
     bands = pipeline.compute(ProcessedWavelengthBands)
     band_dim = (set(bands.dims) - {'wavelength'}).pop()
-
     full_wavelength_range = sc.concat([bands.min(), bands.max()], dim='wavelength')
 
     pipeline = pipeline.copy()
-    # Append full wavelength range as extra band. This allows for running only a
-    # single pipeline to compute both the I(Q) in bands and the I(Q) for the full
-    # wavelength range.
-    pipeline[ProcessedWavelengthBands] = sc.concat(
-        [bands, full_wavelength_range], dim=band_dim
+
+    parts = (
+        CleanSummedQ[SampleRun, Numerator],
+        CleanSummedQ[SampleRun, Denominator],
+        CleanSummedQ[BackgroundRun, Numerator],
+        CleanSummedQ[BackgroundRun, Denominator],
     )
+    parts = pipeline.compute(parts)
+    # For now we simply strip all uncertainties, since direct beam function is
+    # computed without variances anyway.
+    parts = {key: sc.values(result) for key, result in parts.items()}
+    denom_sample = parts[CleanSummedQ[SampleRun, Denominator]]
+    denom_background = parts[CleanSummedQ[BackgroundRun, Denominator]]
+    for key, result in parts.items():
+        pipeline[key] = result
 
     results = []
-
-    # Compute checkpoints to avoid recomputing the same things in every iteration
-    checkpoints = (
-        TransmissionFraction[SampleRun],
-        TransmissionFraction[BackgroundRun],
-        SolidAngle[SampleRun],
-        SolidAngle[BackgroundRun],
-        CleanMonitor[SampleRun, Incident],
-        CleanMonitor[BackgroundRun, Incident],
-        CleanSummedQ[SampleRun, Numerator],
-        CleanSummedQ[BackgroundRun, Numerator],
-    )
-
-    for key, result in pipeline.compute(checkpoints).items():
-        pipeline[key] = result
 
     for it in range(niter):
         print("Iteration", it)
@@ -134,9 +126,10 @@ def direct_beam(pipeline: Pipeline, I0: sc.Variable, niter: int = 5) -> List[dic
         # parameters, nor given by any providers, so it will be considered flat.
         # TODO: Should we have a check that DirectBeam cannot be computed from the
         # pipeline?
-        iofq = sc.values(pipeline.compute(BackgroundSubtractedIofQ))
-        iofq_full = iofq['band', -1]
-        iofq_bands = iofq['band', :-1]
+        pipeline[WavelengthBands] = full_wavelength_range
+        iofq_full = pipeline.compute(BackgroundSubtractedIofQ)
+        pipeline[WavelengthBands] = bands
+        iofq_bands = pipeline.compute(BackgroundSubtractedIofQ)
 
         if direct_beam_function is None:
             # Make a flat direct beam
@@ -153,8 +146,14 @@ def direct_beam(pipeline: Pipeline, I0: sc.Variable, niter: int = 5) -> List[dic
             I0=I0,
         )
 
-        # Insert new direct beam function into pipeline
-        pipeline[DirectBeam] = direct_beam_function
+        # Scale denominator terms that where initially computed without direct beam
+        # with the current direct beam function.
+        db = resample_direct_beam(
+            direct_beam=direct_beam_function,
+            wavelength_bins=pipeline.compute(WavelengthBins),
+        )
+        pipeline[CleanSummedQ[SampleRun, Denominator]] = denom_sample * db
+        pipeline[CleanSummedQ[BackgroundRun, Denominator]] = denom_background * db
 
         results.append(
             {

--- a/src/esssans/normalization.py
+++ b/src/esssans/normalization.py
@@ -366,7 +366,7 @@ def normalize(
                 denominator = broadcast_to_events_with_upper_bound_variances(
                     denominator, events=numerator
                 )
-    else:
+    elif numerator.bins is not None:
         numerator = numerator.hist()
     if numerator.bins is not None and denominator.bins is None:
         da = numerator.bins / sc.lookup(func=denominator, dim='Q')


### PR DESCRIPTION
Follow up to #63 (which reduced time from 1 minute to 15 seconds). This brings it down to about 5 seconds, essentially the time of a norm reduction in this case.

- The iteration itself is very cheap now, timings are almost independent of the iteration count now.
- Computing by, e.g., layers has almost the same cost as without layers.

This used #68, which allows for computation of the $I(Q)$ numerator and denominator as a function of $(\lambda, Q)$. We can then simply scale this, without re-performing the costly spectrum merge. If addition dimensions are kept then the numerator and denominator will have additional dimensions, making them large (and thus everything slightly slower). Unless we do this for each pixel I do not expect a big impact. If required, may be want to switch back to using events in this case.

As a follow-up, we may consider refactoring the direct-beam interface: Since the cost is now mainly in the "setup", we could turn this into an object that can then be used (with minimal cost after creation) to run iterations, change band config, ...