### PR TITLE
Port beam center finder notebook from old docs and fix bug in center finder

### DIFF
--- a/docs/examples/beam-center-finder.ipynb
+++ b/docs/examples/beam-center-finder.ipynb
@@ -103,7 +103,7 @@
     "\n",
     "Adding a mask, based on the pixel neutron counts (integrated along the `tof` dimension),\n",
     "will yield a circular mask around the beam center.\n",
-    "Because the sample holder is highly absorbant to neutrons, such a mask will also mask out the sample holder,\n",
+    "Because the sample holder is highly absorbent to neutrons, such a mask will also mask out the sample holder,\n",
     "making it a very simple but effective way of masking."
    ]
   },

--- a/docs/examples/beam-center-finder.ipynb
+++ b/docs/examples/beam-center-finder.ipynb
@@ -10,11 +10,10 @@
     "In SANS experiments, it is essential to find the center of the scattering pattern in order to allow symmetric summation of the scattering intensity around the beam (i.e. computing a one-dimensional $I(Q)$).\n",
     "As detector panels can move, the center of the beam will not always be located at the same place on the detector panel from one experiment to the next.\n",
     "\n",
-    "Here we describe three different algorithms that can be used to determine the position of the beam center:\n",
+    "Here we describe two different algorithms that can be used to determine the position of the beam center:\n",
     "\n",
-    "1. using the center of mass of the pixel counts\n",
-    "1. using an iterative refinement on a computed scattering cross-section to find the center of the scattering pattern\n",
-    "1. a combination of 1. and 2."
+    "1. Using the center of mass of the pixel counts\n",
+    "1. Using an iterative refinement on a computed scattering cross-section to find the center of the scattering pattern"
    ]
   },
   {
@@ -70,7 +69,7 @@
     "\n",
     "We create a quick image of the data (summing along the `tof` dimension) to inspect its contents.\n",
     "We see a diffuse scattering pattern, centered around a dark patch with an arm to the north-east; this is the sample holder.\n",
-    "It is clear that the sample and the beam are not in the center of the panel, which is marked by the red dot"
+    "It is clear that the sample and the beam are not in the center of the panel, which is marked by the black cross"
    ]
   },
   {
@@ -83,7 +82,7 @@
     "raw = pipeline.compute(RawData[SampleRun])\n",
     "\n",
     "p = plot_flat_detector_xy(raw.sum('tof'), norm='log')\n",
-    "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
+    "p.ax.plot(0, 0, '+', color='k', ms=10)\n",
     "p"
    ]
   },
@@ -136,7 +135,7 @@
     "masked.masks['low_counts'] = masked.sum('tof').data < sc.scalar(80.0, unit='counts')\n",
     "\n",
     "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
-    "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
+    "p.ax.plot(0, 0, '+', color='k', ms=10)\n",
     "p"
    ]
   },
@@ -179,7 +178,7 @@
    "id": "b4b958ad-c03c-47ea-8464-567b64ccde96",
    "metadata": {},
    "source": [
-    "We can now update our previous figure with the new position of the beam center (blue dot),\n",
+    "We can now update our previous figure with the new position of the beam center (pink dot),\n",
     "which is clearly in the center of the beam/sample holder."
    ]
   },
@@ -192,7 +191,7 @@
    "source": [
     "xc = com.fields.x\n",
     "yc = com.fields.y\n",
-    "p.ax.plot(xc.value, yc.value, 'o', color='deepskyblue', ms=5)\n",
+    "p.ax.plot(xc.value, yc.value, 'o', color='magenta', mec='lightgray', ms=6)\n",
     "p"
    ]
   },
@@ -211,9 +210,9 @@
    "source": [
     "The procedure is the following:\n",
     "\n",
-    "1. divide the panel into 4 quadrants\n",
-    "1. compute $I(Q)$ inside each quadrant and compute the residual difference between all 4 quadrants\n",
-    "1. iteratively move the centre position and repeat 1. and 2. until all 4 $I(Q)$ curves lie on top of each other\n",
+    "1. Divide the panel into 4 quadrants\n",
+    "1. Compute $I(Q)$ inside each quadrant and compute the residual difference between all 4 quadrants\n",
+    "1. Iteratively move the center position and repeat 1. and 2. until all 4 $I(Q)$ curves lie on top of each other\n",
     "\n",
     "For this, we need to set-up a fully-fledged pipeline that can compute $I(Q)$,\n",
     "which requires some additional parameters (see the [SANS2D reduction workflow](sans2d.ipynb) for more details)."
@@ -262,7 +261,80 @@
     "\n",
     "# Build the pipeline\n",
     "pipeline = sciline.Pipeline(providers, params=params)\n",
+    "\n",
+    "# Override with data that contains the new mask\n",
+    "pipeline[MaskedData[SampleRun]] = masked\n",
+    "\n",
     "pipeline.visualize(BeamCenter, graph_attr={'rankdir': 'LR'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfe7784a-dd05-48c5-b74c-a006c82d235c",
+   "metadata": {},
+   "source": [
+    "The division of the panel pixels into 4 quadrants,\n",
+    "as well as the iterative procedure to maximize the overlap between the computed intensities,\n",
+    "is all performed internally by the `beam_center_from_iofq` provider (see further details below).\n",
+    "\n",
+    "We can thus compute the beam center in the same way as before:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c087798a-fc33-4292-924c-eed8e3baf36a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "iofq_center = pipeline.compute(BeamCenter)\n",
+    "iofq_center"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76811e12-cf19-41ec-8791-8733c9bb69f2",
+   "metadata": {},
+   "source": [
+    "We, once again, show the location of the computed center (pink dot) on the detector panel:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0d1bd32-6b8a-4236-9ef9-8129d70354c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
+    "p.ax.plot(0, 0, '+', color='k', ms=10)\n",
+    "p.ax.plot(\n",
+    "    iofq_center.value[0],\n",
+    "    iofq_center.value[1],\n",
+    "    'o',\n",
+    "    color='magenta',\n",
+    "    mec='lightgray',\n",
+    "    ms=6,\n",
+    ")\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c32a312-0f07-4441-98df-28609573d3c8",
+   "metadata": {},
+   "source": [
+    "Finally, we can compare the values from the two methods, which should be almost identical:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6db1539b-e482-4758-aa28-a300eded8cb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Center-of-mass:', com.value, '\\nI(Q):          ', iofq_center.value)"
    ]
   },
   {
@@ -270,9 +342,17 @@
    "id": "afbf9a8c-4fc7-4eb3-a477-111baa047b18",
    "metadata": {},
    "source": [
-    "### Making 4 quadrants\n",
+    "## Detailed description of method 2\n",
     "\n",
-    "We divide the panel into 4 quadrants."
+    "In the remainder of this notebook, we will describe in more detail what is done internally for method 2 in the `essans` module.\n",
+    "\n",
+    "The user does not need to understand all the details of the implementation, the information is kept here for completeness.\n",
+    "\n",
+    "### Step 1: divide the panel into 4 quadrants\n",
+    "\n",
+    "We divide the panel into 4 quadrants.\n",
+    "Panels a very commonly rectangular,\n",
+    "and the best way to ensure that each quadrant has approximately the same number of pixels is to make a vertical and a horizontal cut:"
    ]
   },
   {
@@ -285,9 +365,9 @@
    "outputs": [],
    "source": [
     "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
-    "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
     "p.ax.axvline(0, color='cyan')\n",
     "p.ax.axhline(0, color='cyan')\n",
+    "p.ax.plot(0, 0, '+', color='k', ms=10)\n",
     "dx = 0.25\n",
     "style = dict(ha='center', va='center', color='w')\n",
     "p.ax.text(dx, dx, 'North-East', **style)\n",
@@ -302,6 +382,8 @@
    "id": "dccb7b71-8236-4509-b8b1-c20bedfac317",
    "metadata": {},
    "source": [
+    "### Step 2: compute $I(Q)$ inside each quadrant\n",
+    "\n",
     "We define several quantities which are required to compute $I(Q)$:"
    ]
   },
@@ -328,7 +410,7 @@
    "id": "6c335c02-7f17-48fe-9369-f4ed7daacdf3",
    "metadata": {},
    "source": [
-    "And compute $I(Q)$ inside each quadrant:"
+    "We now use a function internal to the `esssans` module compute $I(Q)$ inside each quadrant:"
    ]
   },
   {
@@ -351,7 +433,7 @@
    "id": "31e5b9f9-b0a3-4010-83e8-690fda6e3f76",
    "metadata": {},
    "source": [
-    "We can now plot on the same figure all 4 $I(Q)$ curves for each quadrant."
+    "We can plot on the same figure all 4 $I(Q)$ curves for each quadrant."
    ]
   },
   {
@@ -374,7 +456,9 @@
     "As we can see, the overlap between the curves from the 4 quadrants is completely off.\n",
     "We will now use an iterative procedure to improve our initial guess, until a good overlap between the curves is found.\n",
     "\n",
-    "For this, we first define a cost function, which gives us an idea of how good the overlap is:\n",
+    "### Step 3: iteratively maximize the overlap between the I(Q) curves\n",
+    "\n",
+    "We first define a cost function, which gives us an idea of how good the overlap is:\n",
     "\n",
     "$$\n",
     "\\text{cost} = \\frac{\\sum_{Q}\\sum_{i=1}^{i=4} \\overline{I}(Q)\\left(I(Q)_{i} - \\overline{I}(Q)\\right)^2}{\\sum_{Q}\\overline{I}(Q)} ~,\n",
@@ -467,72 +551,25 @@
    "id": "389c0133-839d-46da-934c-bfcc5e2e5aab",
    "metadata": {},
    "source": [
-    "The overlap between the curves is excellent, allowing us to safely perform an azimuthal summation of the counts around the beam center.\n",
-    "\n",
-    "As a consistency check, we plot the beam center position (blue dot) onto the detector panel image:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6d026294-cbb0-4c2d-bcda-2ec9220a0e66",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
-    "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
-    "p.ax.plot(res.x[0], res.x[1], 'o', color='deepskyblue', ms=5)\n",
-    "p"
+    "The overlap between the curves is excellent, allowing us to safely perform an azimuthal summation of the counts around the beam center."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "99a4a22d-e326-452e-a6a8-c923fd72c331",
+   "id": "3bcc446a-1f04-4161-8f8d-ca782e48ecf7",
    "metadata": {},
    "source": [
-    "Finally, we can compare the values from the two methods, which should be almost identical:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6db1539b-e482-4758-aa28-a300eded8cb9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print('Center-of-mass:', com.value, '\\nI(Q):          ', res.x)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f0345f69-a4ff-4693-a4f8-fd21aa811829",
-   "metadata": {},
-   "source": [
-    "## Hybrid method\n",
+    "<div class=\"alert alert-info\">\n",
     "\n",
-    "In **method 2**, we have used the origin of the panel `[x=0, y=0]` as the initial guess for starting our iterative procedure.\n",
+    "*Note*\n",
     "\n",
-    "However, computing the center-of-mass is very cheap, and we can use it as a very good initial guess,\n",
-    "to obtain a slightly improved value in less iterations:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5eac7b23-8a26-4649-8577-3459dcb4e256",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "res = minimize(\n",
-    "    sans.beam_center_finder._cost,\n",
-    "    x0=[com.value[0], com.value[1]],\n",
-    "    args=tuple(kwargs.values()),\n",
-    "    bounds=bounds,\n",
-    "    method='Nelder-Mead',\n",
-    "    tol=0.01,\n",
-    ")\n",
+    "The result obtained just above (`x=0.09170153, y=-0.08151081`) is slightly different from the one obtained using the pipeline (`x=0.09266183, y=-0.08203386`).\n",
     "\n",
-    "res"
+    "This is because in our example, we used `x=0, y=0` as our initial guess,\n",
+    "while the pipeline uses an additional optimization where it first computes a better initial guess using method 1 (center-of-mass).\n",
+    "This allows it to converge faster, with fewer iterations, and produce a slightly more accurate result.\n",
+    "\n",
+    "</div>"
    ]
   }
  ],

--- a/docs/examples/beam-center-finder.ipynb
+++ b/docs/examples/beam-center-finder.ipynb
@@ -34,27 +34,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "619ee7a0-dd80-4b8b-8c59-5c5e29fbb039",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d3a56490-518c-44ce-8731-98504ebc3ce8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "id": "e84bd5a5-8bed-459b-ad8c-0d04aa6117e0",
    "metadata": {},
    "source": [
-    "We begin by setting some parameters relevant to the current sample."
+    "## Setting up the pipeline\n",
+    "\n",
+    "We begin by setting some parameters for the pipeline,\n",
+    "as well as the name of the data file we wish to use."
    ]
   },
   {
@@ -67,57 +54,10 @@
     "params = sans.sans2d.default_parameters.copy()\n",
     "\n",
     "params[FileList[SampleRun]] = ['SANS2D00063114.hdf5']\n",
-    "params[sans.sans2d.LowCountThreshold] = sc.scalar(100.0, unit='counts')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7224f0ed-b26e-42a8-8a24-3fccc7e0de19",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# # Include effects of gravity?\n",
-    "# gravity = True\n",
     "\n",
-    "# # Wavelength binning\n",
-    "# wavelength_bins = sc.linspace(\n",
-    "#     dim='wavelength', start=2.0, stop=16.0, num=141, unit='angstrom'\n",
-    "# )\n",
-    "\n",
-    "# # Define Q binning\n",
-    "# q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')\n",
-    "\n",
-    "# # Define coordinate transformation graph\n",
-    "# graph = sans.conversions.sans_elastic(gravity=gravity)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e42a73ba-5f47-44b9-b700-f8b947412b02",
-   "metadata": {},
-   "source": [
-    "Next we load the data files for the sample and direct runs:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "323e7114-be3c-40ee-9661-6ec74439938f",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# sample = loki.io.load_sans2d(filename=loki.data.get_path('SANS2D00063114.hdf5'))\n",
-    "# direct = loki.io.load_sans2d(filename=loki.data.get_path('SANS2D00063091.hdf5'))\n",
-    "# # Add X, Y coordinates\n",
-    "# sample.coords['x'] = sample.coords['position'].fields.x\n",
-    "# sample.coords['y'] = sample.coords['position'].fields.y\n",
-    "# # Add gravity coordinate\n",
-    "# sample.coords[\"gravity\"] = sc.vector(value=[0, -1, 0]) * g"
+    "# Build the pipeline\n",
+    "providers = list(sans.providers + sans.sans2d.providers)\n",
+    "pipeline = sciline.Pipeline(providers, params=params)"
    ]
   },
   {
@@ -135,27 +75,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dfb0702a-252b-4f5b-b72b-df4cd93a7e5e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "providers = list(sans.providers + sans.sans2d.providers)\n",
-    "pipeline = sciline.Pipeline(providers, params=params)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20220cb0-3dbf-4588-a579-68bdd2afa198",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pipeline.visualize(MaskedData[SampleRun], graph_attr={'rankdir': 'LR'})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "fdc562a4-7cd5-43fa-8921-5f12a062ecfb",
    "metadata": {},
    "outputs": [],
@@ -163,7 +82,7 @@
     "raw = pipeline.compute(RawData[SampleRun])\n",
     "\n",
     "p = plot_flat_detector_xy(raw.sum('tof'), norm='log')\n",
-    "p.ax.plot(0, 0, 'o', color='red', ms=5)\n",
+    "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
     "p"
    ]
   },
@@ -187,24 +106,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Threshold to mask the sample holder arm\n",
+    "pipeline[sans.sans2d.LowCountThreshold] = sc.scalar(100.0, unit='counts')\n",
+    "\n",
     "masked = pipeline.compute(MaskedData[SampleRun])\n",
     "\n",
     "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
-    "p.ax.plot(0, 0, 'o', color='violet', ms=5)\n",
-    "p"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3e12f295-44ee-4359-9329-3a0163b381d8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "masked.masks['low_counts'] = masked.sum('tof').data < sc.scalar(70., unit='counts')\n",
-    "\n",
-    "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
-    "p.ax.plot(0, 0, 'o', color='violet', ms=5)\n",
+    "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
     "p"
    ]
   },
@@ -213,7 +121,12 @@
    "id": "8e8d553c-b79a-4caa-b875-5583f4454097",
    "metadata": {},
    "source": [
-    "## First method: center-of-mass calculation"
+    "## Method 1: center-of-mass calculation\n",
+    "\n",
+    "The first method we will use to compute the center of the beam is to calculate the center-of-mass of the pixels,\n",
+    "using the integrated counts along the time-of-flight dimension as the weights of the pixel positions.\n",
+    "\n",
+    "We can visualize the pipeline that is used to compute the center-of-mass:"
    ]
   },
   {
@@ -238,6 +151,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b4b958ad-c03c-47ea-8464-567b64ccde96",
+   "metadata": {},
+   "source": [
+    "We can now update our previous figure with the new position of the beam center (blue dot),\n",
+    "which is clearly in the center of the beam/sample holder."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "efe93767-b170-4560-9afd-a6e7a6056344",
@@ -246,7 +168,7 @@
    "source": [
     "xc = com.fields.x\n",
     "yc = com.fields.y\n",
-    "p.ax.plot(xc.value, yc.value, 'o', color='r', ms=5)\n",
+    "p.ax.plot(xc.value, yc.value, 'o', color='deepskyblue', ms=5)\n",
     "p"
    ]
   },
@@ -255,7 +177,7 @@
    "id": "35ba00f1-705e-4307-b338-893323bf3e20",
    "metadata": {},
    "source": [
-    "## Second method: refinement using I(Q) inside 4 quadrants"
+    "## Method 2: computing $I(Q)$ inside 4 quadrants"
    ]
   },
   {
@@ -263,14 +185,14 @@
    "id": "0061b064-c348-4ef4-8d4c-03e729f69074",
    "metadata": {},
    "source": [
-    "### Description of the procedure\n",
+    "The procedure is the following:\n",
     "\n",
-    "The procedure to determine the precise location of the beam center is the following:\n",
+    "1. divide the panel into 4 quadrants\n",
+    "1. compute $I(Q)$ inside each quadrant and compute the residual difference between all 4 quadrants\n",
+    "1. iteratively move the centre position and repeat 1. and 2. until all 4 $I(Q)$ curves lie on top of each other\n",
     "\n",
-    "1. use the center-of-mass as an initial guess\n",
-    "2. from that initial guess, divide the panel into 4 quadrants\n",
-    "3. compute $I(Q)$ inside each quadrant and compute the residual difference between all 4 quadrants\n",
-    "4. iteratively move the centre position and repeat 2. and 3. until all 4 $I(Q)$ curves lie on top of each other"
+    "For this, we need to set-up a fully-fledged pipeline that can compute $I(Q)$,\n",
+    "which requires some additional parameters (see the [SANS2D reduction workflow](sans2d.ipynb) for more details)."
    ]
   },
   {
@@ -304,8 +226,11 @@
     "        'Q', 0.02, 0.3, 71, unit='1/angstrom'\n",
     "    )\n",
     "\n",
+    "# We remove the center-of-mass finder and replace it with the one that uses I(Q)\n",
     "providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)\n",
     "providers.append(sans.beam_center_finder.beam_center_from_iofq)\n",
+    "\n",
+    "# Build the pipeline\n",
     "pipeline = sciline.Pipeline(providers, params=params)\n",
     "pipeline.visualize(BeamCenter, graph_attr={'rankdir': 'LR'})"
    ]
@@ -330,15 +255,15 @@
    "outputs": [],
    "source": [
     "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
-    "p.ax.plot(xc.value, yc.value, 'o', color='red', ms=5)\n",
-    "p.ax.axvline(xc.value, color='cyan')\n",
-    "p.ax.axhline(yc.value, color='cyan')\n",
+    "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
+    "p.ax.axvline(0, color='cyan')\n",
+    "p.ax.axhline(0, color='cyan')\n",
     "dx = 0.25\n",
     "style = dict(ha='center', va='center', color='w')\n",
-    "p.ax.text(xc.value + dx, yc.value + dx, 'North-East', **style)\n",
-    "p.ax.text(xc.value - dx, yc.value + dx, 'North-West', **style)\n",
-    "p.ax.text(xc.value + dx, yc.value - dx, 'South-East', **style)\n",
-    "p.ax.text(xc.value - dx, yc.value - dx, 'South-West', **style)\n",
+    "p.ax.text(dx, dx, 'North-East', **style)\n",
+    "p.ax.text(-dx, dx, 'North-West', **style)\n",
+    "p.ax.text(dx, -dx, 'South-East', **style)\n",
+    "p.ax.text(-dx, -dx, 'South-West', **style)\n",
     "p"
    ]
   },
@@ -347,9 +272,7 @@
    "id": "dccb7b71-8236-4509-b8b1-c20bedfac317",
    "metadata": {},
    "source": [
-    "### Compute $I(Q)$ inside the 4 quadrants\n",
-    "\n",
-    "We begin by defining several parameters which are required to compute $I(Q)$."
+    "We define several quantities which are required to compute $I(Q)$:"
    ]
   },
   {
@@ -359,13 +282,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kwargs = dict(data= masked,\n",
-    "norm=pipeline.compute(NormWavelengthTerm[SampleRun]),\n",
-    "graph=pipeline.compute(sans.conversions.ElasticCoordTransformGraph),\n",
-    "q_bins=params[sans.beam_center_finder.BeamCenterFinderQBins],\n",
-    "wavelength_bins=params[WavelengthBins],\n",
-    "transform=pipeline.compute(LabFrameTransform[SampleRun]),\n",
-    "pixel_shape=pipeline.compute(DetectorPixelShape[SampleRun]))"
+    "kwargs = dict(\n",
+    "    data=masked,\n",
+    "    norm=pipeline.compute(NormWavelengthTerm[SampleRun]),\n",
+    "    graph=pipeline.compute(sans.conversions.ElasticCoordTransformGraph),\n",
+    "    q_bins=params[sans.beam_center_finder.BeamCenterFinderQBins],\n",
+    "    wavelength_bins=params[WavelengthBins],\n",
+    "    transform=pipeline.compute(LabFrameTransform[SampleRun]),\n",
+    "    pixel_shape=pipeline.compute(DetectorPixelShape[SampleRun]))"
    ]
   },
   {
@@ -378,7 +302,7 @@
     "from esssans.beam_center_finder import _iofq_in_quadrants\n",
     "\n",
     "results = _iofq_in_quadrants(\n",
-    "    xy=[xc.value, yc.value],\n",
+    "    xy=[0, 0],\n",
     "    **kwargs,\n",
     ")"
    ]
@@ -429,16 +353,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a46560bb-d2ab-483f-8b7e-1292a029c2c8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "xc"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "27898815-7742-4990-853f-15d665f0337e",
    "metadata": {
     "tags": []
@@ -453,10 +367,10 @@
     "\n",
     "res = minimize(\n",
     "    sans.beam_center_finder._cost,\n",
-    "    x0=[xc.value, yc.value],\n",
+    "    x0=[0, 0],\n",
     "    args=tuple(kwargs.values()),\n",
     "    bounds=[(x.min().value, x.max().value), (y.min().value, y.max().value)],\n",
-    "    method='Nelder-Mead',\n",
+    "    method='Powell',\n",
     "    tol=0.01,\n",
     ")\n",
     "\n",
@@ -500,11 +414,8 @@
    },
    "outputs": [],
    "source": [
-    "xy = [ 0.09329701, -0.08079138]\n",
-    "\n",
     "results = _iofq_in_quadrants(\n",
-    "    # xy=[res.x[0], res.x[1]],\n",
-    "    xy=xy,\n",
+    "    xy=[res.x[0], res.x[1]],\n",
     "    **kwargs,\n",
     ")\n",
     "\n",
@@ -524,28 +435,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f627d98e-5c3f-404e-b6f6-59ba2386a5bb",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "p = sample.sum('tof').copy().hist(y=120, x=128).plot(norm='log', aspect='equal')\n",
-    "p.ax.plot(res.x[0], res.x[1], 'o', color='red', ms=5)\n",
-    "p"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "6d026294-cbb0-4c2d-bcda-2ec9220a0e66",
    "metadata": {},
    "outputs": [],
    "source": [
     "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
-    "p.ax.plot(res.x[0], res.x[1], 'o', color='red', ms=5)\n",
-    "# p.ax.axvline(xc.value, color='cyan')\n",
-    "# p.ax.axhline(yc.value, color='cyan')\n",
+    "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
+    "p.ax.plot(res.x[0], res.x[1], 'o', color='deepskyblue', ms=5)\n",
     "p"
    ]
   },
@@ -587,8 +483,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/docs/examples/beam-center-finder.ipynb
+++ b/docs/examples/beam-center-finder.ipynb
@@ -308,14 +308,7 @@
    "source": [
     "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
     "p.ax.plot(0, 0, '+', color='k', ms=10)\n",
-    "p.ax.plot(\n",
-    "    iofq_center.value[0],\n",
-    "    iofq_center.value[1],\n",
-    "    'o',\n",
-    "    color='magenta',\n",
-    "    mec='lightgray',\n",
-    "    ms=6,\n",
-    ")\n",
+    "p.ax.plot(iofq_center.value[0], iofq_center.value[1], 'o', color='magenta', mec='lightgray', ms=6)\n",
     "p"
    ]
   },
@@ -453,7 +446,7 @@
    "id": "db6a4f3e-3edf-4eae-8662-b971d9e6e19a",
    "metadata": {},
    "source": [
-    "As we can see, the overlap between the curves from the 4 quadrants is completely off.\n",
+    "As we can see, the overlap between the curves from the 4 quadrants is mediocre.\n",
     "We will now use an iterative procedure to improve our initial guess, until a good overlap between the curves is found.\n",
     "\n",
     "### Step 3: iteratively maximize the overlap between the I(Q) curves\n",
@@ -563,7 +556,7 @@
     "\n",
     "*Note*\n",
     "\n",
-    "The result obtained just above (`x=0.09170153, y=-0.08151081`) is slightly different from the one obtained using the pipeline (`x=0.09266183, y=-0.08203386`).\n",
+    "The result obtained just above (`x=0.0917016, y=-0.08151084`) is slightly different from the one obtained using the pipeline (`x=0.09266183, y=-0.08203386`).\n",
     "\n",
     "This is because in our example, we used `x=0, y=0` as our initial guess,\n",
     "while the pipeline uses an additional optimization where it first computes a better initial guess using method 1 (center-of-mass).\n",

--- a/docs/examples/beam-center-finder.ipynb
+++ b/docs/examples/beam-center-finder.ipynb
@@ -10,10 +10,11 @@
     "In SANS experiments, it is essential to find the center of the scattering pattern in order to allow symmetric summation of the scattering intensity around the beam (i.e. computing a one-dimensional $I(Q)$).\n",
     "As detector panels can move, the center of the beam will not always be located at the same place on the detector panel from one experiment to the next.\n",
     "\n",
-    "Here we describe two different algorithms that can be used to determine the position of the beam center:\n",
+    "Here we describe three different algorithms that can be used to determine the position of the beam center:\n",
     "\n",
     "1. using the center of mass of the pixel counts\n",
-    "1. using an iterative refinement on a computed scattering cross-section to find the center of the scattering pattern"
+    "1. using an iterative refinement on a computed scattering cross-section to find the center of the scattering pattern\n",
+    "1. a combination of 1. and 2."
    ]
   },
   {
@@ -165,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "642192bc-4e94-468c-bc37-5e0920e6b47d",
+   "id": "36107cf1-da94-43c4-a1c3-68f168a07e37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,9 +249,9 @@
     ")\n",
     "params[FileList[TransmissionRun[SampleRun]]] = params[FileList[SampleRun]]\n",
     "params[FileList[EmptyBeamRun]] = ['SANS2D00063091.hdf5']\n",
+    "\n",
     "params[CorrectForGravity] = True\n",
     "params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound\n",
-    "\n",
     "params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(\n",
     "    'Q', 0.02, 0.25, 71, unit='1/angstrom'\n",
     ")\n",
@@ -402,12 +403,13 @@
     "# The minimizer works best if given bounds, which are the bounds of our detector panel\n",
     "x = masked.coords['position'].fields.x\n",
     "y = masked.coords['position'].fields.y\n",
+    "bounds = [(x.min().value, x.max().value), (y.min().value, y.max().value)]\n",
     "\n",
     "res = minimize(\n",
     "    sans.beam_center_finder._cost,\n",
     "    x0=[0, 0],\n",
     "    args=tuple(kwargs.values()),\n",
-    "    bounds=[(x.min().value, x.max().value), (y.min().value, y.max().value)],\n",
+    "    bounds=bounds,\n",
     "    method='Powell',\n",
     "    tol=0.01,\n",
     ")\n",
@@ -467,7 +469,7 @@
    "source": [
     "The overlap between the curves is excellent, allowing us to safely perform an azimuthal summation of the counts around the beam center.\n",
     "\n",
-    "As a consistency check, we plot the refined beam center position onto the detector panel image:"
+    "As a consistency check, we plot the beam center position (blue dot) onto the detector panel image:"
    ]
   },
   {
@@ -499,6 +501,38 @@
    "outputs": [],
    "source": [
     "print('Center-of-mass:', com.value, '\\nI(Q):          ', res.x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0345f69-a4ff-4693-a4f8-fd21aa811829",
+   "metadata": {},
+   "source": [
+    "## Hybrid method\n",
+    "\n",
+    "In **method 2**, we have used the origin of the panel `[x=0, y=0]` as the initial guess for starting our iterative procedure.\n",
+    "\n",
+    "However, computing the center-of-mass is very cheap, and we can use it as a very good initial guess,\n",
+    "to obtain a slightly improved value in less iterations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5eac7b23-8a26-4649-8577-3459dcb4e256",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = minimize(\n",
+    "    sans.beam_center_finder._cost,\n",
+    "    x0=[com.value[0], com.value[1]],\n",
+    "    args=tuple(kwargs.values()),\n",
+    "    bounds=bounds,\n",
+    "    method='Nelder-Mead',\n",
+    "    tol=0.01,\n",
+    ")\n",
+    "\n",
+    "res"
    ]
   }
  ],

--- a/docs/examples/beam-center-finder.ipynb
+++ b/docs/examples/beam-center-finder.ipynb
@@ -88,15 +88,40 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25a4c118-65fd-4d90-89e9-2cf901239c56",
+   "id": "2981ea30-ebae-4ca4-b3c3-b50ad186bae3",
    "metadata": {},
    "source": [
-    "To avoid skew in future comparisons of integrated intensities between the different regions of the detector panel,\n",
-    "we mask out the sample holder, using a low-counts threshold.\n",
-    "This also masks out the edges of the panel, which show visible artifacts.\n",
-    "We also mask out a region in the bottom right corner where a group of hot pixels is apparent.\n",
-    "Finally, there is a single hot pixel in the detector on the right edge of the panel with counts in excess of 1000,\n",
-    "which we also remove."
+    "The scattering pattern is circularly symmetric around the center of the beam.\n",
+    "Because the beam is not in the center of the panel, different regions of the panel are covering different radial ranges.\n",
+    "\n",
+    "When searching for the center of the beam, it is important to remove any such bias that would skew the computed center position.\n",
+    "We basically would like to add a circular mask around the center, to ensure the same radial range is reached in all directions.\n",
+    "\n",
+    "Unfortunately, we do not know the center, because that is what we are trying to compute.\n",
+    "We can however use the fact that the scattering pattern is symmetric,\n",
+    "and that the intensity is higher close to the beam while lower towards the edges of the panel.\n",
+    "\n",
+    "Adding a mask, based on the pixel neutron counts (integrated along the `tof` dimension),\n",
+    "will yield a circular mask around the beam center.\n",
+    "Because the sample holder is highly absorbant to neutrons, such a mask will also mask out the sample holder,\n",
+    "making it a very simple but effective way of masking."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c1b0bb4-229e-4b7a-a2f2-7883afbd710d",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "*Note*\n",
+    "\n",
+    "In general, for a fully normalized data reduction, masks based on counts are not recommended\n",
+    "as they can remove true regions of zero counts and not just artifacts.\n",
+    "They should only be used in controlled cases, where the end result does not require a correctly\n",
+    "normalized intensity.\n",
+    "\n",
+    "</div>"
    ]
   },
   {
@@ -106,10 +131,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Threshold to mask the sample holder arm\n",
-    "pipeline[sans.sans2d.LowCountThreshold] = sc.scalar(100.0, unit='counts')\n",
-    "\n",
     "masked = pipeline.compute(MaskedData[SampleRun])\n",
+    "masked.masks['low_counts'] = masked.sum('tof').data < sc.scalar(80., unit='counts')\n",
     "\n",
     "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
     "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
@@ -196,6 +219,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "5e8700d8-27b7-44e5-bc7e-616bb4850329",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "\n",
+    "*Note*\n",
+    "\n",
+    "In the full $I(Q)$ reduction, there is a term $D(\\lambda)$ in the normalization called the \"direct beam\" which gives the efficiency of the detectors as a function of wavelength.\n",
+    "Because finding the beam center is required to compute the direct beam in the first place,\n",
+    "we do not include this term in the computation of $I(Q)$ for finding the beam center.\n",
+    "This changes the shape of the $I(Q)$ curve, but since it changes it in the same manner for all $\\phi$ angles,\n",
+    "this does not affect the results for finding the beam center.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "f43d6ddd-6106-4b8e-bc81-5f7b98b58078",
@@ -205,25 +246,13 @@
     "params[WavelengthBins] = sc.linspace(\n",
     "    'wavelength', start=2.0, stop=16.0, num=141, unit='angstrom'\n",
     ")\n",
-    "params[WavelengthMask] = sc.DataArray(\n",
-    "    data=sc.array(dims=['wavelength'], values=[True]),\n",
-    "    coords={\n",
-    "        'wavelength': sc.array(\n",
-    "            dims=['wavelength'], values=[2.21, 2.59], unit='angstrom'\n",
-    "        )\n",
-    "    },\n",
-    ")\n",
     "params[FileList[TransmissionRun[SampleRun]]] = params[FileList[SampleRun]]\n",
     "params[FileList[EmptyBeamRun]] = ['SANS2D00063091.hdf5']\n",
-    "\n",
-    "params[NonBackgroundWavelengthRange] = sc.array(\n",
-    "    dims=['wavelength'], values=[0.7, 17.1], unit='angstrom'\n",
-    ")\n",
     "params[CorrectForGravity] = True\n",
     "params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound\n",
     "\n",
     "params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(\n",
-    "        'Q', 0.02, 0.3, 71, unit='1/angstrom'\n",
+    "        'Q', 0.02, 0.25, 71, unit='1/angstrom'\n",
     "    )\n",
     "\n",
     "# We remove the center-of-mass finder and replace it with the one that uses I(Q)\n",
@@ -293,6 +322,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "6c335c02-7f17-48fe-9369-f4ed7daacdf3",
+   "metadata": {},
+   "source": [
+    "And compute $I(Q)$ inside each quadrant:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "224eb405-f167-4337-91a3-860d56ae8a0c",
@@ -332,7 +369,7 @@
    "id": "db6a4f3e-3edf-4eae-8662-b971d9e6e19a",
    "metadata": {},
    "source": [
-    "As we can see, the overlap between the curves from the 4 quadrants is not satisfactory.\n",
+    "As we can see, the overlap between the curves from the 4 quadrants is completely off.\n",
     "We will now use an iterative procedure to improve our initial guess, until a good overlap between the curves is found.\n",
     "\n",
     "For this, we first define a cost function, which gives us an idea of how good the overlap is:\n",
@@ -447,24 +484,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0c58240d-7034-4467-b86c-d2f985a86e8c",
+   "id": "99a4a22d-e326-452e-a6a8-c923fd72c331",
    "metadata": {},
    "source": [
-    "## Footnotes"
+    "Finally, we can compare the values from the two methods, which should be almost identical:"
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "d723ce70-f424-477b-94e9-29d6fbed802e",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6db1539b-e482-4758-aa28-a300eded8cb9",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "<div id='footnote1'></div>\n",
-    "\n",
-    "1. In the full $I(Q)$ reduction, there is a term $D(\\lambda)$ in the normalization called the \"direct beam\" which gives the efficiency of the detectors as a function of wavelength.\n",
-    "Because finding the beam center is required to compute the direct beam in the first place,\n",
-    "we do not include this term in the computation of $I(Q)$ for finding the beam center.\n",
-    "This changes the shape of the $I(Q)$ curve, but since it changes it in the same manner for all $\\phi$ angles,\n",
-    "this does not affect the results for finding the beam center."
+    "print('Center-of-mass:', com.value, '\\nI(Q):          ', res.x)"
    ]
   }
  ],

--- a/docs/examples/beam-center-finder.ipynb
+++ b/docs/examples/beam-center-finder.ipynb
@@ -132,7 +132,7 @@
    "outputs": [],
    "source": [
     "masked = pipeline.compute(MaskedData[SampleRun])\n",
-    "masked.masks['low_counts'] = masked.sum('tof').data < sc.scalar(80., unit='counts')\n",
+    "masked.masks['low_counts'] = masked.sum('tof').data < sc.scalar(80.0, unit='counts')\n",
     "\n",
     "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
     "p.ax.plot(0, 0, 'o', color='deeppink', ms=5)\n",
@@ -252,8 +252,8 @@
     "params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound\n",
     "\n",
     "params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(\n",
-    "        'Q', 0.02, 0.25, 71, unit='1/angstrom'\n",
-    "    )\n",
+    "    'Q', 0.02, 0.25, 71, unit='1/angstrom'\n",
+    ")\n",
     "\n",
     "# We remove the center-of-mass finder and replace it with the one that uses I(Q)\n",
     "providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)\n",
@@ -318,7 +318,8 @@
     "    q_bins=params[sans.beam_center_finder.BeamCenterFinderQBins],\n",
     "    wavelength_bins=params[WavelengthBins],\n",
     "    transform=pipeline.compute(LabFrameTransform[SampleRun]),\n",
-    "    pixel_shape=pipeline.compute(DetectorPixelShape[SampleRun]))"
+    "    pixel_shape=pipeline.compute(DetectorPixelShape[SampleRun]),\n",
+    ")"
    ]
   },
   {

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -8,4 +8,5 @@ maxdepth: 2
 sans2d
 loki-direct-beam
 zoom
+beam-center-finder
 ```

--- a/docs/examples/sans-beam-center-finder.ipynb
+++ b/docs/examples/sans-beam-center-finder.ipynb
@@ -1,0 +1,596 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fc46c62a-499c-4b12-a65d-f40946f5f46f",
+   "metadata": {},
+   "source": [
+    "# Beam center finder\n",
+    "\n",
+    "In SANS experiments, it is essential to find the center of the scattering pattern in order to allow symmetric summation of the scattering intensity around the beam (i.e. computing a one-dimensional $I(Q)$).\n",
+    "As detector panels can move, the center of the beam will not always be located at the same place on the detector panel from one experiment to the next.\n",
+    "\n",
+    "Here we describe two different algorithms that can be used to determine the position of the beam center:\n",
+    "\n",
+    "1. using the center of mass of the pixel counts\n",
+    "1. using an iterative refinement on a computed scattering cross-section to find the center of the scattering pattern"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f68a06b0-8982-43b2-b180-942c3dd49b5e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import scipp as sc\n",
+    "import plopp as pp\n",
+    "import sciline as sl\n",
+    "import esssans as sans\n",
+    "from esssans.isis import plot_flat_detector_xy\n",
+    "from esssans.types import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "619ee7a0-dd80-4b8b-8c59-5c5e29fbb039",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3a56490-518c-44ce-8731-98504ebc3ce8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e84bd5a5-8bed-459b-ad8c-0d04aa6117e0",
+   "metadata": {},
+   "source": [
+    "We begin by setting some parameters relevant to the current sample."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "327a8b3c-fdde-45cd-9f29-dc33f9bb101d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params = sans.sans2d.default_parameters.copy()\n",
+    "\n",
+    "params[FileList[SampleRun]] = ['SANS2D00063114.hdf5']\n",
+    "params[sans.sans2d.LowCountThreshold] = sc.scalar(100.0, unit='counts')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7224f0ed-b26e-42a8-8a24-3fccc7e0de19",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# # Include effects of gravity?\n",
+    "# gravity = True\n",
+    "\n",
+    "# # Wavelength binning\n",
+    "# wavelength_bins = sc.linspace(\n",
+    "#     dim='wavelength', start=2.0, stop=16.0, num=141, unit='angstrom'\n",
+    "# )\n",
+    "\n",
+    "# # Define Q binning\n",
+    "# q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')\n",
+    "\n",
+    "# # Define coordinate transformation graph\n",
+    "# graph = sans.conversions.sans_elastic(gravity=gravity)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e42a73ba-5f47-44b9-b700-f8b947412b02",
+   "metadata": {},
+   "source": [
+    "Next we load the data files for the sample and direct runs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "323e7114-be3c-40ee-9661-6ec74439938f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# sample = loki.io.load_sans2d(filename=loki.data.get_path('SANS2D00063114.hdf5'))\n",
+    "# direct = loki.io.load_sans2d(filename=loki.data.get_path('SANS2D00063091.hdf5'))\n",
+    "# # Add X, Y coordinates\n",
+    "# sample.coords['x'] = sample.coords['position'].fields.x\n",
+    "# sample.coords['y'] = sample.coords['position'].fields.y\n",
+    "# # Add gravity coordinate\n",
+    "# sample.coords[\"gravity\"] = sc.vector(value=[0, -1, 0]) * g"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ae3315b-ab76-4fbc-9d6e-594b31d2fae6",
+   "metadata": {},
+   "source": [
+    "### Masking bad pixels\n",
+    "\n",
+    "We create a quick image of the data (summing along the `tof` dimension) to inspect its contents.\n",
+    "We see a diffuse scattering pattern, centered around a dark patch with an arm to the north-east; this is the sample holder.\n",
+    "It is clear that the sample and the beam are not in the center of the panel, which is marked by the red dot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfb0702a-252b-4f5b-b72b-df4cd93a7e5e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "providers = list(sans.providers + sans.sans2d.providers)\n",
+    "pipeline = sciline.Pipeline(providers, params=params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20220cb0-3dbf-4588-a579-68bdd2afa198",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.visualize(MaskedData[SampleRun], graph_attr={'rankdir': 'LR'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fdc562a4-7cd5-43fa-8921-5f12a062ecfb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw = pipeline.compute(RawData[SampleRun])\n",
+    "\n",
+    "p = plot_flat_detector_xy(raw.sum('tof'), norm='log')\n",
+    "p.ax.plot(0, 0, 'o', color='red', ms=5)\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25a4c118-65fd-4d90-89e9-2cf901239c56",
+   "metadata": {},
+   "source": [
+    "To avoid skew in future comparisons of integrated intensities between the different regions of the detector panel,\n",
+    "we mask out the sample holder, using a low-counts threshold.\n",
+    "This also masks out the edges of the panel, which show visible artifacts.\n",
+    "We also mask out a region in the bottom right corner where a group of hot pixels is apparent.\n",
+    "Finally, there is a single hot pixel in the detector on the right edge of the panel with counts in excess of 1000,\n",
+    "which we also remove."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bf3c65d-09b4-4e17-97d0-d2039bb1b05d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "masked = pipeline.compute(MaskedData[SampleRun])\n",
+    "\n",
+    "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
+    "p.ax.plot(0, 0, 'o', color='violet', ms=5)\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e12f295-44ee-4359-9329-3a0163b381d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "masked.masks['low_counts'] = masked.sum('tof').data < sc.scalar(70., unit='counts')\n",
+    "\n",
+    "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
+    "p.ax.plot(0, 0, 'o', color='violet', ms=5)\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e8d553c-b79a-4caa-b875-5583f4454097",
+   "metadata": {},
+   "source": [
+    "## First method: center-of-mass calculation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0e4b26a-4143-4e8d-9061-bb5f25d5553a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.visualize(BeamCenter, graph_attr={'rankdir': 'LR'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "642192bc-4e94-468c-bc37-5e0920e6b47d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "com = pipeline.compute(BeamCenter)\n",
+    "com"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efe93767-b170-4560-9afd-a6e7a6056344",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xc = com.fields.x\n",
+    "yc = com.fields.y\n",
+    "p.ax.plot(xc.value, yc.value, 'o', color='r', ms=5)\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35ba00f1-705e-4307-b338-893323bf3e20",
+   "metadata": {},
+   "source": [
+    "## Second method: refinement using I(Q) inside 4 quadrants"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0061b064-c348-4ef4-8d4c-03e729f69074",
+   "metadata": {},
+   "source": [
+    "### Description of the procedure\n",
+    "\n",
+    "The procedure to determine the precise location of the beam center is the following:\n",
+    "\n",
+    "1. use the center-of-mass as an initial guess\n",
+    "2. from that initial guess, divide the panel into 4 quadrants\n",
+    "3. compute $I(Q)$ inside each quadrant and compute the residual difference between all 4 quadrants\n",
+    "4. iteratively move the centre position and repeat 2. and 3. until all 4 $I(Q)$ curves lie on top of each other"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f43d6ddd-6106-4b8e-bc81-5f7b98b58078",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "params[WavelengthBins] = sc.linspace(\n",
+    "    'wavelength', start=2.0, stop=16.0, num=141, unit='angstrom'\n",
+    ")\n",
+    "params[WavelengthMask] = sc.DataArray(\n",
+    "    data=sc.array(dims=['wavelength'], values=[True]),\n",
+    "    coords={\n",
+    "        'wavelength': sc.array(\n",
+    "            dims=['wavelength'], values=[2.21, 2.59], unit='angstrom'\n",
+    "        )\n",
+    "    },\n",
+    ")\n",
+    "params[FileList[TransmissionRun[SampleRun]]] = params[FileList[SampleRun]]\n",
+    "params[FileList[EmptyBeamRun]] = ['SANS2D00063091.hdf5']\n",
+    "\n",
+    "params[NonBackgroundWavelengthRange] = sc.array(\n",
+    "    dims=['wavelength'], values=[0.7, 17.1], unit='angstrom'\n",
+    ")\n",
+    "params[CorrectForGravity] = True\n",
+    "params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound\n",
+    "\n",
+    "params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(\n",
+    "        'Q', 0.02, 0.3, 71, unit='1/angstrom'\n",
+    "    )\n",
+    "\n",
+    "providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)\n",
+    "providers.append(sans.beam_center_finder.beam_center_from_iofq)\n",
+    "pipeline = sciline.Pipeline(providers, params=params)\n",
+    "pipeline.visualize(BeamCenter, graph_attr={'rankdir': 'LR'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "afbf9a8c-4fc7-4eb3-a477-111baa047b18",
+   "metadata": {},
+   "source": [
+    "### Making 4 quadrants\n",
+    "\n",
+    "We divide the panel into 4 quadrants."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bfdb5422-4c71-4e65-a4be-e7fd6042c203",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
+    "p.ax.plot(xc.value, yc.value, 'o', color='red', ms=5)\n",
+    "p.ax.axvline(xc.value, color='cyan')\n",
+    "p.ax.axhline(yc.value, color='cyan')\n",
+    "dx = 0.25\n",
+    "style = dict(ha='center', va='center', color='w')\n",
+    "p.ax.text(xc.value + dx, yc.value + dx, 'North-East', **style)\n",
+    "p.ax.text(xc.value - dx, yc.value + dx, 'North-West', **style)\n",
+    "p.ax.text(xc.value + dx, yc.value - dx, 'South-East', **style)\n",
+    "p.ax.text(xc.value - dx, yc.value - dx, 'South-West', **style)\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dccb7b71-8236-4509-b8b1-c20bedfac317",
+   "metadata": {},
+   "source": [
+    "### Compute $I(Q)$ inside the 4 quadrants\n",
+    "\n",
+    "We begin by defining several parameters which are required to compute $I(Q)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56960e8c-511b-45c6-b068-ff6a3905e2e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kwargs = dict(data= masked,\n",
+    "norm=pipeline.compute(NormWavelengthTerm[SampleRun]),\n",
+    "graph=pipeline.compute(sans.conversions.ElasticCoordTransformGraph),\n",
+    "q_bins=params[sans.beam_center_finder.BeamCenterFinderQBins],\n",
+    "wavelength_bins=params[WavelengthBins],\n",
+    "transform=pipeline.compute(LabFrameTransform[SampleRun]),\n",
+    "pixel_shape=pipeline.compute(DetectorPixelShape[SampleRun]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "224eb405-f167-4337-91a3-860d56ae8a0c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from esssans.beam_center_finder import _iofq_in_quadrants\n",
+    "\n",
+    "results = _iofq_in_quadrants(\n",
+    "    xy=[xc.value, yc.value],\n",
+    "    **kwargs,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31e5b9f9-b0a3-4010-83e8-690fda6e3f76",
+   "metadata": {},
+   "source": [
+    "We can now plot on the same figure all 4 $I(Q)$ curves for each quadrant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "007524f6-96b6-4bf7-9130-8d42db118b95",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pp.plot(results, norm='log')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db6a4f3e-3edf-4eae-8662-b971d9e6e19a",
+   "metadata": {},
+   "source": [
+    "As we can see, the overlap between the curves from the 4 quadrants is not satisfactory.\n",
+    "We will now use an iterative procedure to improve our initial guess, until a good overlap between the curves is found.\n",
+    "\n",
+    "For this, we first define a cost function, which gives us an idea of how good the overlap is:\n",
+    "\n",
+    "$$\n",
+    "\\text{cost} = \\frac{\\sum_{Q}\\sum_{i=1}^{i=4} \\overline{I}(Q)\\left(I(Q)_{i} - \\overline{I}(Q)\\right)^2}{\\sum_{Q}\\overline{I}(Q)} ~,\n",
+    "$$\n",
+    "\n",
+    "where $\\overline{I}(Q)$ is the mean intensity of the 4 quadrants (represented by $i$) as a function of $Q$.\n",
+    "This is basically a weighted mean of the square of the differences between the $I(Q)$ curves in the 4 quadrants with respect to $\\overline{I}(Q)$,\n",
+    "and where the weights are $\\overline{I}(Q)$.\n",
+    "\n",
+    "Next, we iteratively minimize the computed cost\n",
+    "(this is using Scipy's `optimize.minimize` utility internally;\n",
+    "see [here](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html) for more details)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a46560bb-d2ab-483f-8b7e-1292a029c2c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27898815-7742-4990-853f-15d665f0337e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from scipy.optimize import minimize\n",
+    "\n",
+    "# The minimizer works best if given bounds, which are the bounds of our detector panel\n",
+    "x = masked.coords['position'].fields.x\n",
+    "y = masked.coords['position'].fields.y\n",
+    "\n",
+    "res = minimize(\n",
+    "    sans.beam_center_finder._cost,\n",
+    "    x0=[xc.value, yc.value],\n",
+    "    args=tuple(kwargs.values()),\n",
+    "    bounds=[(x.min().value, x.max().value), (y.min().value, y.max().value)],\n",
+    "    method='Nelder-Mead',\n",
+    "    tol=0.01,\n",
+    ")\n",
+    "\n",
+    "res"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8f125a8-38ec-4792-8e82-4d2b2e4860e4",
+   "metadata": {},
+   "source": [
+    "Once the iterations completed, the returned object contains the best estimate for the beam center:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81965cb9-bb34-4662-9210-e2904952759c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "res.x"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d7e7739-935d-46fa-88eb-5367d70f8278",
+   "metadata": {},
+   "source": [
+    "We can now feed this value again into our `iofq_in_quadrants` function, to inspect the $Q$ intensity in all 4 quadrants:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bba5ad6e-294d-4549-8a2b-74e693f1f923",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "xy = [ 0.09329701, -0.08079138]\n",
+    "\n",
+    "results = _iofq_in_quadrants(\n",
+    "    # xy=[res.x[0], res.x[1]],\n",
+    "    xy=xy,\n",
+    "    **kwargs,\n",
+    ")\n",
+    "\n",
+    "pp.plot(results, norm='log')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "389c0133-839d-46da-934c-bfcc5e2e5aab",
+   "metadata": {},
+   "source": [
+    "The overlap between the curves is excellent, allowing us to safely perform an azimuthal summation of the counts around the beam center.\n",
+    "\n",
+    "As a consistency check, we plot the refined beam center position onto the detector panel image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f627d98e-5c3f-404e-b6f6-59ba2386a5bb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "p = sample.sum('tof').copy().hist(y=120, x=128).plot(norm='log', aspect='equal')\n",
+    "p.ax.plot(res.x[0], res.x[1], 'o', color='red', ms=5)\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d026294-cbb0-4c2d-bcda-2ec9220a0e66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = plot_flat_detector_xy(masked.sum('tof'), norm='log')\n",
+    "p.ax.plot(res.x[0], res.x[1], 'o', color='red', ms=5)\n",
+    "# p.ax.axvline(xc.value, color='cyan')\n",
+    "# p.ax.axhline(yc.value, color='cyan')\n",
+    "p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c58240d-7034-4467-b86c-d2f985a86e8c",
+   "metadata": {},
+   "source": [
+    "## Footnotes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d723ce70-f424-477b-94e9-29d6fbed802e",
+   "metadata": {},
+   "source": [
+    "<div id='footnote1'></div>\n",
+    "\n",
+    "1. In the full $I(Q)$ reduction, there is a term $D(\\lambda)$ in the normalization called the \"direct beam\" which gives the efficiency of the detectors as a function of wavelength.\n",
+    "Because finding the beam center is required to compute the direct beam in the first place,\n",
+    "we do not include this term in the computation of $I(Q)$ for finding the beam center.\n",
+    "This changes the shape of the $I(Q)$ curve, but since it changes it in the same manner for all $\\phi$ angles,\n",
+    "this does not affect the results for finding the beam center."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -394,7 +394,7 @@ def beam_center_from_iofq(
 
     logger.info(f'Requested minimizer: {minimizer}')
     logger.info(f'Requested tolerance: {tolerance}')
-    minimizer = minimizer or 'Nedler-Mead'
+    minimizer = minimizer or 'Nelder-Mead'
     tolerance = tolerance or 0.1
     logger.info(f'Using minimizer: {minimizer}')
     logger.info(f'Using tolerance: {tolerance}')

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -383,8 +383,8 @@ def beam_center_from_iofq(
     Because finding the beam center is required to compute the direct beam in the first
     place, we do not include this term in the computation of :math:`I(Q)` for finding
     the beam center. This changes the shape of the :math:`I(Q)` curve, but since it
-    changes it in the same manner for all :math:`{\\phi}` angles, this does not affect the
-    results for finding the beam center.
+    changes it in the same manner for all :math:`{\\phi}` angles, this does not affect
+    the results for finding the beam center.
 
     This is what is now implemented in this version of the algorithm.
     """  # noqa: E501

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -21,8 +21,8 @@ from .logging import get_logger
 from .normalization import iofq_denominator, normalize, solid_angle
 from .types import (
     BeamCenter,
-    DetectorPixelShape,
     CalibratedMaskedData,
+    DetectorPixelShape,
     IofQ,
     LabFrameTransform,
     MaskedData,

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -394,8 +394,8 @@ def beam_center_from_iofq(
 
     logger.info(f'Requested minimizer: {minimizer}')
     logger.info(f'Requested tolerance: {tolerance}')
-    minimizer = minimizer or 'Powell'
-    tolerance = tolerance or 0.01
+    minimizer = minimizer or 'Nedler-Mead'
+    tolerance = tolerance or 0.1
     logger.info(f'Using minimizer: {minimizer}')
     logger.info(f'Using tolerance: {tolerance}')
 

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -257,14 +257,12 @@ def _cost(xy: List[float], *args) -> float:
     out = (sc.sum(ref * c) / sc.sum(ref)).value
     logger = get_logger('sans')
     if not np.isfinite(out):
-        iofq_values = all_q.values
-        out = 1.0e6 * iofq_values[np.isfinite(iofq_values)].max()
+        out = np.inf
         logger.info(
             'Non-finite value computed in cost. This is likely due to a division by '
-            'zero. The value was artificially changed to a large finite number. '
-            'If the results are not satisfactory, try restricting your Q range, or '
-            'increasing the size of your Q bins to improve statistics in the '
-            'denominator.'
+            'zero. If the final results for the beam center are not satisfactory, '
+            'try restricting your Q range, or increasing the size of your Q bins to '
+            'improve statistics in the denominator.'
         )
     logger.info(f'Beam center finder: x={xy[0]}, y={xy[1]}, cost={out}')
     return out

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -256,13 +256,17 @@ def _cost(xy: List[float], *args) -> float:
     c = (all_q - ref) ** 2
     out = (sc.sum(ref * c) / sc.sum(ref)).value
     logger = get_logger('sans')
-    logger.info(f'Beam center finder: x={xy[0]}, y={xy[1]}, cost={out}')
     if not np.isfinite(out):
-        raise ValueError(
+        iofq_values = all_q.values
+        out = 1.0e6 * iofq_values[np.isfinite(iofq_values)].max()
+        logger.info(
             'Non-finite value computed in cost. This is likely due to a division by '
-            'zero. Try restricting your Q range, or increasing the size of your Q bins '
-            'to improve statistics in the denominator.'
+            'zero. The value was artificially changed to a large finite number. '
+            'If the results are not satisfactory, try restricting your Q range, or '
+            'increasing the size of your Q bins to improve statistics in the '
+            'denominator.'
         )
+    logger.info(f'Beam center finder: x={xy[0]}, y={xy[1]}, cost={out}')
     return out
 
 

--- a/src/esssans/beam_center_finder.py
+++ b/src/esssans/beam_center_finder.py
@@ -390,8 +390,8 @@ def beam_center_from_iofq(
 
     logger.info(f'Requested minimizer: {minimizer}')
     logger.info(f'Requested tolerance: {tolerance}')
-    minimizer = minimizer or 'Nelder-Mead'
-    tolerance = tolerance or 0.1
+    minimizer = minimizer or 'Powell'
+    tolerance = tolerance or 0.01
     logger.info(f'Using minimizer: {minimizer}')
     logger.info(f'Using tolerance: {tolerance}')
 

--- a/src/esssans/isis/visualization.py
+++ b/src/esssans/isis/visualization.py
@@ -3,6 +3,7 @@
 """
 Plotting functions for ISIS data.
 """
+import warnings
 from typing import Any
 
 import scipp as sc
@@ -45,4 +46,7 @@ def plot_flat_detector_xy(
         )
     plot_kwargs = dict(aspect='equal')
     plot_kwargs.update(kwargs)
-    return folded.plot(**plot_kwargs)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        out = folded.plot(**plot_kwargs)
+    return out

--- a/tests/sans2d/reduction_test.py
+++ b/tests/sans2d/reduction_test.py
@@ -9,6 +9,7 @@ import scipp as sc
 
 import esssans as sans
 from esssans.sans2d import default_parameters
+from esssans.sans2d.masking import LowCountThreshold, SampleHolderMask
 from esssans.types import (
     BackgroundRun,
     BackgroundSubtractedIofQ,
@@ -187,18 +188,18 @@ def test_pixel_dependent_direct_beam_is_supported(uncertainties):
     assert result.dims == ('Q',)
 
 
+MANTID_BEAM_CENTER = sc.vector([0.09288, -0.08195, 0], unit='m')
+
+
 def test_beam_center_from_center_of_mass_is_close_to_verified_result():
     params = make_params()
     providers = sans2d_providers()
     pipeline = sciline.Pipeline(providers, params=params)
     center = pipeline.compute(BeamCenter)
-    # This is the result we got with the pre-sciline implementation, using the full IofQ
-    # calculation. The difference is about 5 mm in X or Y, probably due to a bias
+    # This is the result obtained from Mantid, using the full IofQ
+    # calculation. The difference is about 3 mm in X or Y, probably due to a bias
     # introduced by the sample holder, which the center-of-mass approach cannot ignore.
-    center_pre_sciline_raw_solid_angle = sc.vector([0.0945643, -0.082074, 0], unit='m')
-    assert sc.allclose(
-        center, center_pre_sciline_raw_solid_angle, atol=sc.scalar(5e-3, unit='m')
-    )
+    assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(3e-3, unit='m'))
 
 
 def test_beam_center_finder_without_direct_beam_reproduces_verified_result():
@@ -212,13 +213,30 @@ def test_beam_center_finder_without_direct_beam_reproduces_verified_result():
     providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
     center = pipeline.compute(BeamCenter)
-    # This is the result we got with the pre-sciline implementation
-    # The difference is that the reference result computed the solid angle only once,
-    # before applying any detector positions shifts.
-    center_pre_sciline_raw_solid_angle = sc.vector([0.0945643, -0.082074, 0], unit='m')
-    assert sc.allclose(
-        center, center_pre_sciline_raw_solid_angle, atol=sc.scalar(4e-3, unit='m')
+    assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(2e-3, unit='m'))
+
+
+def test_beam_center_can_get_closer_to_verified_result_with_low_counts_mask():
+    def low_counts_mask(
+        sample: RawData[SampleRun],
+        low_counts_threshold: LowCountThreshold,
+    ) -> SampleHolderMask:
+        return SampleHolderMask(sample.data.sum('tof') < low_counts_threshold)
+
+    params = make_params()
+    params[LowCountThreshold] = sc.scalar(80.0, unit='counts')
+    params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(
+        'Q', 0.02, 0.3, 71, unit='1/angstrom'
     )
+    del params[DirectBeamFilename]
+    providers = sans2d_providers()
+    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
+    providers.remove(sans.sans2d.masking.sample_holder_mask)
+    providers.append(sans.beam_center_finder.beam_center_from_iofq)
+    providers.append(low_counts_mask)
+    pipeline = sciline.Pipeline(providers, params=params)
+    center = pipeline.compute(BeamCenter)
+    assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(5e-4, unit='m'))
 
 
 def test_beam_center_finder_works_with_direct_beam():
@@ -230,10 +248,10 @@ def test_beam_center_finder_works_with_direct_beam():
     providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
     providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
-    center = pipeline.compute(BeamCenter)  # (0.0951122, -0.079375, 0)
-    center_no_direct_beam = sc.vector([0.0945643, -0.082074, 0], unit='m')
-
-    assert sc.allclose(center, center_no_direct_beam, atol=sc.scalar(1e-2, unit='m'))
+    center_with_direct_beam = pipeline.compute(BeamCenter)
+    assert sc.allclose(
+        center_with_direct_beam, MANTID_BEAM_CENTER, atol=sc.scalar(2e-3, unit='m')
+    )
 
 
 def test_beam_center_finder_works_with_pixel_dependent_direct_beam():


### PR DESCRIPTION
- Porting the old notebook from https://scipp.github.io/ess/techniques/sans/sans-beam-center-finder.html

- Also fixed a bug in the beam center finder based on I(Q) where `phi` positions for selecting pixels in the 4 quadrants were being computed on the raw uncalibrated data, instead of the calibrated data. This meant that while we were computing I(Q) using the correct pixel positions, when comparing 4 quadrants to get the curves to overlap, we were comparing data from quadrants not symmetrically divided around the newly found center, but around the origin `[0, 0]`.