### PR TITLE
Temporary fix for Loki masking

### DIFF
--- a/src/esssans/loki/masking.py
+++ b/src/esssans/loki/masking.py
@@ -26,25 +26,23 @@ DetectorTubeEdgeMask = NewType('DetectorTubeEdgeMask', sc.Variable)
 
 
 def detector_straw_mask(
-    sample_straws: RawData[SampleRun],
+    data: RawData[SampleRun],
 ) -> DetectorLowCountsStrawMask:
     """
     This mask aims to remove straws with low counts. It is based on the assumption
-    that the integrated counts in a straw should be at least greater than the number of
-    pixels in the straw (within a fudge factor of 0.5).
+    that the integrated counts in a straw should be at least greater than a fraction of
+    the maximum integrated counts in a straw (fraction set to 1% here).
     This is not true for straws that are not hit by the beam.
     Because the straws are horizontal, this mask will typically mask straws that are
     at the top and bottom edges of the detector panel.
     Note that this has only been tested on the main rear detector panel.
     """
-    return DetectorLowCountsStrawMask(
-        sample_straws.sum('pixel').data
-        < sc.scalar(sample_straws.sizes['pixel'] * 0.5, unit='counts')
-    )
+    pixel_sum = data.sum('pixel').data
+    return DetectorLowCountsStrawMask(pixel_sum < pixel_sum.max() * 0.01)
 
 
 def detector_beam_stop_mask(
-    sample_straws: RawData[SampleRun],
+    data: RawData[SampleRun],
     beam_stop_position: BeamStopPosition,
     beam_stop_radius: BeamStopRadius,
 ) -> DetectorBeamStopMask:
@@ -55,28 +53,25 @@ def detector_beam_stop_mask(
     data as an input). Therefore, only a rough estimate of the beam position is used.
     Note that this has only been tested on the main rear detector panel.
     """
-    pos = sample_straws.coords['position'] - beam_stop_position
+    pos = data.coords['position'] - beam_stop_position
     pos.fields.z *= 0.0
     return DetectorBeamStopMask((sc.norm(pos) < beam_stop_radius))
 
 
 def detector_tube_edge_mask(
-    sample_straws: RawData[SampleRun],
+    data: RawData[SampleRun],
 ) -> DetectorTubeEdgeMask:
     """
     This mask aims to remove the left and right edges of the detector panel.
     Those areas typically have low counts. This mask is based on the assumption
     that the counts integrated inside a vertical slab (summed over the ``straw`` and
-    ``layer`` dimensions) should be at least greater that the number of pixels that
-    make up the slab (within a fudge factor of 0.5).
+    ``layer`` dimensions) should be at least greater that a fraction of
+    the maximum integrated counts in a slab (fraction set to 5% here).
     This is not true for slabs that are not hit by the beam.
     Note that this has only been tested on the main rear detector panel.
     """
-    other_dims = set(sample_straws.dims) - {'pixel'}
-    size = np.prod([sample_straws.sizes[dim] for dim in other_dims])
-    return DetectorTubeEdgeMask(
-        sample_straws.sum(other_dims).data < sc.scalar(size * 0.5, unit='counts')
-    )
+    other_dims_sum = data.sum(set(data.dims) - {'pixel'}).data
+    return DetectorTubeEdgeMask(other_dims_sum < other_dims_sum.max() * 0.05)
 
 
 def mask_detectors(

--- a/src/esssans/loki/masking.py
+++ b/src/esssans/loki/masking.py
@@ -5,7 +5,6 @@ Masking functions for the loki workflow.
 """
 from typing import NewType, Optional
 
-import numpy as np
 import scipp as sc
 
 from ..types import (

--- a/tests/loki/iofq_test.py
+++ b/tests/loki/iofq_test.py
@@ -194,7 +194,9 @@ def test_beam_center_from_center_of_mass_is_close_to_verified_result():
     params = make_params()
     pipeline = sciline.Pipeline(loki_providers(), params=params)
     center = pipeline.compute(BeamCenter)
-    reference = sc.vector([-0.0309889, -0.0168854, 0], unit='m')
+    # Value obtained from running pipeline after updated masking:
+    # https://github.com/scipp/esssans/pull/91
+    reference = sc.vector([-0.0310485, -0.0167454, 0], unit='m')
     assert sc.allclose(center, reference)
 
 

--- a/tests/loki/iofq_test.py
+++ b/tests/loki/iofq_test.py
@@ -171,21 +171,22 @@ def test_pipeline_IofQ_merging_events_yields_consistent_results():
     )
     iofq1 = pipeline_single.compute(BackgroundSubtractedIofQ)
     iofq3 = pipeline_triple.compute(BackgroundSubtractedIofQ)
-    print(abs(sc.values(iofq1) - sc.values(iofq3)).max())
-    print(abs((sc.values(iofq1) - sc.values(iofq3)) / sc.values(iofq1)).max())
+    assert sc.allclose(sc.values(iofq1.data), sc.values(iofq3.data))
+    assert sc.identical(iofq1.coords['Q'], iofq3.coords['Q'])
+    assert all(sc.variances(iofq1.data) > sc.variances(iofq3.data))
     assert sc.allclose(
-        sc.values(iofq1), sc.values(iofq3), atol=sc.scalar(1e-6), rtol=sc.scalar(1e-3)
+        sc.values(
+            pipeline_single.compute(CleanSummedQ[SampleRun, Numerator]).hist().data
+        )
+        * N,
+        sc.values(
+            pipeline_triple.compute(CleanSummedQ[SampleRun, Numerator]).hist().data
+        ),
     )
-    assert all(sc.variances(iofq1) > sc.variances(iofq3))
     assert sc.allclose(
-        sc.values(pipeline_single.compute(CleanSummedQ[SampleRun, Numerator])) * N,
-        sc.values(pipeline_triple.compute(CleanSummedQ[SampleRun, Numerator])),
-        rtol=sc.scalar(1e-6),
-    )
-    assert sc.allclose(
-        sc.values(pipeline_single.compute(CleanSummedQ[SampleRun, Denominator])) * N,
-        sc.values(pipeline_triple.compute(CleanSummedQ[SampleRun, Denominator])),
-        rtol=sc.scalar(1e-6),
+        sc.values(pipeline_single.compute(CleanSummedQ[SampleRun, Denominator]).data)
+        * N,
+        sc.values(pipeline_triple.compute(CleanSummedQ[SampleRun, Denominator]).data),
     )
 
 


### PR DESCRIPTION
We had an issue with masking when merging multiple runs in the Loki workflow,

For example, to mask the straws at the top and bottom of the panel, we summed the counts inside each straw, and compared that to the number of pixels in each straw. This means that all you need to do is merge the events from 2 runs, and you will have approximately double the events but the number of pixels stays the same.
So now, in some straws, double the events means you are above the threshold and you start to mask less straws. The more runs you merge, the less straws you mask.

I've 'fixed' this by using a different threshold (based on the max of the counts integrated inside one straw), but this is still based on counts, and will probably break again in the future.

We need to sit down and come up with a better way of masking things.