### PR TITLE
Try cyclebane

### DIFF
--- a/docs/user-guide/isis/zoom.ipynb
+++ b/docs/user-guide/isis/zoom.ipynb
@@ -136,8 +136,7 @@
     "    isis.data.transmission_from_sample_run,\n",
     "    sans.beam_center_from_center_of_mass,\n",
     ")\n",
-    "pipeline = sciline.Pipeline(providers, params=params)\n",
-    "pipeline.set_param_series(PixelMaskFilename, masks)"
+    "pipeline = sciline.Pipeline(providers, params=params)"
    ]
   },
   {
@@ -176,6 +175,35 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f942232",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cyclebane as cb\n",
+    "\n",
+    "\n",
+    "def merge(*dicts: dict) -> dict:\n",
+    "    return {k: v for d in dicts for k, v in d.items()}\n",
+    "\n",
+    "\n",
+    "def make_workflow(\n",
+    "    pipeline: sciline.Pipeline, masks: list[str]\n",
+    ") -> sciline.task_graph.TaskGraph:\n",
+    "    graph = pipeline.get(\n",
+    "        IofQ[SampleRun], handler=sciline.HandleAsComputeTimeException()\n",
+    "    )\n",
+    "    cbgraph = cb.Graph(graph.to_networkx())\n",
+    "    cbgraph[MaskedDetectorIDs] = (\n",
+    "        cbgraph[MaskedDetectorIDs]\n",
+    "        .map({PixelMaskFilename: masks})\n",
+    "        .reduce(attrs={\"reduce\": merge})\n",
+    "    )\n",
+    "    return sciline.task_graph.TaskGraph.from_networkx(cbgraph.to_networkx())"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "703ffc1e",
    "metadata": {},
@@ -192,7 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "iofq = pipeline.get(IofQ[SampleRun])\n",
+    "iofq = make_workflow(pipeline, masks)\n",
     "iofq.visualize(graph_attr={'rankdir': 'LR'}, compact=True)"
    ]
   },
@@ -232,13 +260,13 @@
    "source": [
     "monitors = (\n",
     "    WavelengthMonitor[SampleRun, Incident],\n",
-    "    WavelengthMonitor[SampleRun, Transmission],\n",
+    "    WavelengthMonitor[TransmissionRun[SampleRun], Transmission],\n",
     ")\n",
     "parts = (CleanSummedQ[SampleRun, Numerator], CleanSummedQ[SampleRun, Denominator])\n",
     "iofqs = (IofQ[SampleRun],)\n",
     "keys = monitors + (MaskedData[SampleRun],) + parts + iofqs\n",
     "\n",
-    "results = pipeline.compute(keys)\n",
+    "results = iofq.compute(keys)\n",
     "\n",
     "display(sc.plot({str(key): results[key] for key in monitors}, norm='log'))\n",
     "\n",
@@ -248,7 +276,7 @@
     "    )\n",
     ")\n",
     "\n",
-    "wavelength = pipeline.compute(WavelengthBins)\n",
+    "wavelength = iofq.compute(WavelengthBins)\n",
     "display(\n",
     "    results[CleanSummedQ[SampleRun, Numerator]]\n",
     "    .hist(wavelength=wavelength)\n",
@@ -291,7 +319,7 @@
     "    'Qy': sc.linspace(dim='Qy', start=-0.8, stop=0.8, num=101, unit='1/angstrom'),\n",
     "}\n",
     "\n",
-    "iqxqy = pipeline.compute(IofQ[SampleRun])\n",
+    "iqxqy = make_workflow(pipeline, masks).compute(IofQ[SampleRun])\n",
     "iqxqy.plot(norm='log', aspect='equal')"
    ]
   }
@@ -311,7 +339,8 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3"
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/src/ess/isissans/io.py
+++ b/src/ess/isissans/io.py
@@ -59,9 +59,8 @@ def read_xml_detector_masking(
                 else:
                     masked_detids.append(int(detid))
 
-    return MaskedDetectorIDs(
-        sc.array(dims=['detector_id'], values=masked_detids, unit=None, dtype='int32')
-    )
+    ids = sc.array(dims=['detector_id'], values=masked_detids, unit=None, dtype='int32')
+    return MaskedDetectorIDs({filename: ids})
 
 
 providers = (read_xml_detector_masking, to_path)

--- a/src/ess/sans/masking.py
+++ b/src/ess/sans/masking.py
@@ -3,24 +3,14 @@
 """
 Masking functions for the loki workflow.
 """
-from typing import Optional
-
 import numpy as np
-import sciline
 import scipp as sc
 
-from .types import (
-    MaskedData,
-    MaskedDetectorIDs,
-    PixelMaskFilename,
-    ScatteringRunType,
-    TofData,
-)
+from .types import MaskedData, MaskedDetectorIDs, ScatteringRunType, TofData
 
 
 def apply_pixel_masks(
-    data: TofData[ScatteringRunType],
-    masked_ids: Optional[sciline.Series[PixelMaskFilename, MaskedDetectorIDs]],
+    data: TofData[ScatteringRunType], masked_ids: MaskedDetectorIDs
 ) -> MaskedData[ScatteringRunType]:
     """Apply pixel-specific masks to raw data.
     The masks are based on detector IDs stored in XML files.

--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -168,7 +168,7 @@ class Filename(sciline.Scope[RunType, str], str):
     """Filename of a run"""
 
 
-MaskedDetectorIDs = NewType('MaskedDetectorIDs', sc.Variable)
+MaskedDetectorIDs = NewType('MaskedDetectorIDs', dict[str, sc.Variable])
 """1-D variable listing all masked detector IDs."""
 
 


### PR DESCRIPTION
This demonstrates how Cyclebane could be used to replace param tables, on the example of pixel masks. See the updated Zoom notebook.

To run this, you need:
- Sciline @ `cyclebane` branch
- [Cyclebane](https://github.com/scipp/cyclebane) @ `map-reduce` branch

Note: Tests failing, since I did not refactor those to replace the use of param tables.