### PR TITLE
Split load of detector/monitor from event-data load

### DIFF
--- a/docs/user-guide/common/beam-center-finder.ipynb
+++ b/docs/user-guide/common/beam-center-finder.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw = workflow.compute(RawData[SampleRun])['spectrum', :61440]\n",
+    "raw = workflow.compute(RawDetector[SampleRun])['spectrum', :61440]\n",
     "\n",
     "p = isis.plot_flat_detector_xy(raw.hist(), norm='log')\n",
     "p.ax.plot(0, 0, '+', color='k', ms=10)\n",
@@ -128,6 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "workflow[BeamCenter] = sc.vector(value=[0, 0, 0], unit='m')\n",
     "masked = workflow.compute(MaskedData[SampleRun])['spectrum', :61440].copy()\n",
     "masked.masks['low_counts'] = masked.hist().data < sc.scalar(80.0, unit='counts')\n",
     "\n",
@@ -156,9 +157,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Insert the provider that computes the center-of-mass of the pixels\n",
-    "workflow.insert(sans.beam_center_finder.beam_center_from_center_of_mass)\n",
-    "workflow.visualize(BeamCenter, graph_attr={'rankdir': 'LR'})"
+    "# The center-of-mass approach is based on the MaskedData\n",
+    "workflow.visualize(MaskedData[SampleRun])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7aac9d0",
+   "metadata": {},
+   "source": [
+    "We use the workflow to fill in the required arguments and call the function:"
    ]
   },
   {
@@ -168,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "com = workflow.compute(BeamCenter)\n",
+    "com = sans.beam_center_finder.beam_center_from_center_of_mass(workflow)\n",
     "com"
    ]
   },
@@ -245,11 +253,7 @@
     "workflow = isis.sans2d.Sans2dTutorialWorkflow()\n",
     "# For real data use:\n",
     "# workflow = isis.sans2d.Sans2dWorkflow()\n",
-    "\n",
-    "workflow.insert(isis.data.transmission_from_sample_run)\n",
-    "# Insert the provider that computes the center from I(Q) curves\n",
-    "workflow.insert(sans.beam_center_finder.beam_center_from_iofq)\n",
-    "workflow.visualize(BeamCenter, graph_attr={'rankdir': 'LR'})"
+    "workflow.insert(isis.data.transmission_from_sample_run)"
    ]
   },
   {
@@ -280,12 +284,8 @@
     "\n",
     "workflow[CorrectForGravity] = True\n",
     "workflow[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound\n",
-    "workflow[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(\n",
-    "    'Q', 0.02, 0.25, 71, unit='1/angstrom'\n",
-    ")\n",
-    "workflow[sans.beam_center_finder.BeamCenterFinderMinimizer] = None\n",
-    "workflow[sans.beam_center_finder.BeamCenterFinderTolerance] = None\n",
-    "workflow[DirectBeam] = None"
+    "workflow[DirectBeam] = None\n",
+    "workflow[isis.sans2d.LowCountThreshold] = sc.scalar(-1, unit=\"counts\")"
    ]
   },
   {
@@ -293,7 +293,7 @@
    "id": "641be8e9",
    "metadata": {},
    "source": [
-    "Finally, we set the data to be used, including overriding with data that contains the new mask defined earlier:"
+    "Finally, we set the data to be used, including overriding with the new mask defined earlier:"
    ]
   },
   {
@@ -304,7 +304,10 @@
    "outputs": [],
    "source": [
     "workflow[Filename[SampleRun]] = isis.data.sans2d_tutorial_sample_run()\n",
-    "workflow[MaskedData[SampleRun]] = masked"
+    "detector = workflow.compute(RawDetector[SampleRun])['spectrum', :61440].assign_masks(\n",
+    "    masked.masks\n",
+    ")\n",
+    "workflow[RawDetector[SampleRun]] = detector"
    ]
   },
   {
@@ -322,11 +325,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c087798a-fc33-4292-924c-eed8e3baf36a",
+   "id": "329a0cd9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "iofq_center = workflow.compute(BeamCenter)\n",
+    "q_bins = sc.linspace('Q', 0.02, 0.25, 71, unit='1/angstrom')\n",
+    "workflow[BeamCenter] = sc.vector([0, 0, 0], unit='m')\n",
+    "iofq_center = sans.beam_center_finder.beam_center_from_iofq(\n",
+    "    workflow=workflow, q_bins=q_bins\n",
+    ")\n",
     "iofq_center"
    ]
   },
@@ -433,14 +440,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "workflow = workflow.copy()\n",
+    "workflow[QBins] = q_bins\n",
+    "workflow[ReturnEvents] = False\n",
+    "workflow[DimsToKeep] = ()\n",
+    "workflow[WavelengthMask] = None\n",
+    "workflow[WavelengthBands] = None\n",
     "kwargs = dict(  # noqa: C408\n",
-    "    data=masked,\n",
+    "    workflow=workflow,\n",
+    "    detector=detector,\n",
     "    norm=workflow.compute(NormWavelengthTerm[SampleRun]),\n",
-    "    graph=workflow.compute(sans.conversions.ElasticCoordTransformGraph),\n",
-    "    q_bins=workflow.compute(sans.beam_center_finder.BeamCenterFinderQBins),\n",
-    "    wavelength_bins=workflow.compute(WavelengthBins),\n",
-    "    transform=workflow.compute(LabFrameTransform[SampleRun]),\n",
-    "    pixel_shape=workflow.compute(DetectorPixelShape[SampleRun]),\n",
     ")"
    ]
   },
@@ -628,7 +637,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/isis/sans2d.ipynb
+++ b/docs/user-guide/isis/sans2d.ipynb
@@ -72,8 +72,7 @@
    "outputs": [],
    "source": [
     "workflow.insert(isis.data.transmission_from_background_run)\n",
-    "workflow.insert(isis.data.transmission_from_sample_run)\n",
-    "workflow.insert(sans.beam_center_from_center_of_mass)"
+    "workflow.insert(isis.data.transmission_from_sample_run)"
    ]
   },
   {
@@ -165,6 +164,44 @@
     "workflow[Filename[SampleRun]] = isis.data.sans2d_tutorial_sample_run()\n",
     "workflow[Filename[BackgroundRun]] = isis.data.sans2d_tutorial_background_run()\n",
     "workflow[Filename[EmptyBeamRun]] = isis.data.sans2d_tutorial_empty_beam_run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "981f1f28",
+   "metadata": {},
+   "source": [
+    "The beam center is not set yet.\n",
+    "Unless we have a previously computed value, we can do so now:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "064f87a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "center = sans.beam_center_from_center_of_mass(workflow)\n",
+    "center"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d7ce61a",
+   "metadata": {},
+   "source": [
+    "Remember to update the workflow with the new center:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a4c43f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow[BeamCenter] = center"
    ]
   },
   {
@@ -391,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/isis/zoom.ipynb
+++ b/docs/user-guide/isis/zoom.ipynb
@@ -71,8 +71,7 @@
    "metadata": {},
    "source": [
     "We can insert steps for configuring the workflow.\n",
-    "In this case, we would like to use the transmission monitor from the regular background and sample runs since there was no separate transmission run.\n",
-    "We also want to compute the beam center using a simple center-of-mass estimation:"
+    "In this case, we would like to use the transmission monitor from the regular background and sample runs since there was no separate transmission run."
    ]
   },
   {
@@ -83,8 +82,7 @@
    "outputs": [],
    "source": [
     "workflow.insert(isis.data.transmission_from_background_run)\n",
-    "workflow.insert(isis.data.transmission_from_sample_run)\n",
-    "workflow.insert(sans.beam_center_from_center_of_mass)"
+    "workflow.insert(isis.data.transmission_from_sample_run)"
    ]
   },
   {
@@ -175,6 +173,29 @@
    "metadata": {},
    "source": [
     "## Use the workflow\n",
+    "\n",
+    "### Set or compute the beam center\n",
+    "\n",
+    "The beam center is not set by default.\n",
+    "We can either set it to a known value, or compute it from the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "568cd4be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow[BeamCenter] = sans.beam_center_from_center_of_mass(workflow)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13ddd330",
+   "metadata": {},
+   "source": [
+    "\n",
     "\n",
     "### Compute final result\n",
     "\n",

--- a/docs/user-guide/loki/loki-direct-beam.ipynb
+++ b/docs/user-guide/loki/loki-direct-beam.ipynb
@@ -190,36 +190,8 @@
     "and inserting the provider that will compute the beam center.\n",
     "\n",
     "For now, we compute the beam center only for the rear detector (named 'larmor_detector') but apply it to all banks (currently there is only one bank).\n",
-    "The beam center may need to be computed or applied differently to each bank, see [scipp/esssans#28](https://github.com/scipp/esssans/issues/28)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bdc15ab4-6ec6-4a29-81dc-1d00a8e890dc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bc_workflow = workflow.copy()\n",
-    "bc_workflow.insert(sans.beam_center_from_center_of_mass)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7cc2cf3b-973e-4425-93ea-deb30b12c956",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bc_workflow.visualize(BeamCenter, compact=True, graph_attr={'rankdir': 'LR'})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b6bf5342-6768-4b65-882b-aefc9b583724",
-   "metadata": {},
-   "source": [
-    "We can now compute the value for the center"
+    "The beam center may need to be computed or applied differently to each bank, see [scipp/esssans#28](https://github.com/scipp/esssans/issues/28).\n",
+    "We use a center-of-mass approach to find the beam center:"
    ]
   },
   {
@@ -229,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "center = bc_workflow.compute(BeamCenter)\n",
+    "center = sans.beam_center_from_center_of_mass(workflow)\n",
     "center"
    ]
   },
@@ -238,7 +210,7 @@
    "id": "0814805a-9611-4951-a015-c12ae254b099",
    "metadata": {},
    "source": [
-    "and set that value onto our original workflow"
+    "and set that value in our workflow"
    ]
   },
   {
@@ -639,7 +611,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/src/ess/isissans/components.py
+++ b/src/ess/isissans/components.py
@@ -6,11 +6,11 @@ import sciline
 import scipp as sc
 
 from ..sans.types import (
-    ConfiguredReducibleData,
-    ConfiguredReducibleMonitor,
     MonitorType,
-    RawData,
+    RawDetector,
+    RawDetectorData,
     RawMonitor,
+    RawMonitorData,
     RunType,
     ScatteringRunType,
 )
@@ -25,10 +25,10 @@ DetectorBankOffset = NewType('DetectorBankOffset', sc.Variable)
 
 
 def apply_component_user_offsets_to_raw_data(
-    data: RawData[ScatteringRunType],
+    data: RawDetector[ScatteringRunType],
     sample_offset: SampleOffset,
     detector_bank_offset: DetectorBankOffset,
-) -> ConfiguredReducibleData[ScatteringRunType]:
+) -> RawDetectorData[ScatteringRunType]:
     """Apply user offsets to raw data.
 
     Parameters
@@ -47,13 +47,13 @@ def apply_component_user_offsets_to_raw_data(
     )
     pos = data.coords['position']
     data.coords['position'] = pos + detector_bank_offset.to(unit=pos.unit, copy=False)
-    return ConfiguredReducibleData[ScatteringRunType](data)
+    return RawDetectorData[ScatteringRunType](data)
 
 
 def apply_component_user_offsets_to_raw_monitor(
     monitor_data: RawMonitor[RunType, MonitorType],
     monitor_offset: MonitorOffset[MonitorType],
-) -> ConfiguredReducibleMonitor[RunType, MonitorType]:
+) -> RawMonitorData[RunType, MonitorType]:
     """Apply user offsets to raw monitor.
     Parameters
     ----------
@@ -65,7 +65,7 @@ def apply_component_user_offsets_to_raw_monitor(
     monitor_data = monitor_data.copy(deep=False)
     pos = monitor_data.coords['position']
     monitor_data.coords['position'] = pos + monitor_offset.to(unit=pos.unit, copy=False)
-    return ConfiguredReducibleMonitor[RunType, MonitorType](monitor_data)
+    return RawMonitorData[RunType, MonitorType](monitor_data)
 
 
 providers = (

--- a/src/ess/isissans/general.py
+++ b/src/ess/isissans/general.py
@@ -10,6 +10,7 @@ from ..sans.types import (
     ConfiguredReducibleData,
     ConfiguredReducibleMonitor,
     CorrectForGravity,
+    DetectorIDs,
     DetectorPixelShape,
     DimsToKeep,
     Incident,
@@ -122,8 +123,23 @@ def lab_frame_transform() -> LabFrameTransform[ScatteringRunType]:
     return sc.spatial.rotation(value=[0, 0, 1 / 2**0.5, 1 / 2**0.5])
 
 
+def get_detector_ids_from_sample_run(data: TofData[SampleRun]) -> DetectorIDs:
+    """Extract detector IDs from sample run.
+
+    This overrides the function in the masking module which gets the detector IDs from
+    the detector before loading event data. In this ISIS case files are loaded using
+    Mantid which does not load event separately, so we get IDs from the data.
+    """
+    return DetectorIDs(
+        data.coords[
+            'detector_number' if 'detector_number' in data.coords else 'detector_id'
+        ]
+    )
+
+
 providers = (
     get_detector_data,
+    get_detector_ids_from_sample_run,
     get_monitor_data,
     data_to_tof,
     monitor_to_tof,

--- a/src/ess/isissans/general.py
+++ b/src/ess/isissans/general.py
@@ -7,8 +7,6 @@ Providers for the ISIS instruments.
 import scipp as sc
 
 from ..sans.types import (
-    ConfiguredReducibleData,
-    ConfiguredReducibleMonitor,
     CorrectForGravity,
     DetectorIDs,
     DetectorPixelShape,
@@ -18,8 +16,10 @@ from ..sans.types import (
     MonitorType,
     NeXusMonitorName,
     NonBackgroundWavelengthRange,
-    RawData,
+    RawDetector,
+    RawDetectorData,
     RawMonitor,
+    RawMonitorData,
     RunNumber,
     RunTitle,
     RunType,
@@ -53,8 +53,8 @@ def default_parameters() -> dict:
 
 def get_detector_data(
     dg: LoadedFileContents[RunType],
-) -> RawData[RunType]:
-    return RawData[RunType](dg['data'])
+) -> RawDetector[RunType]:
+    return RawDetector[RunType](dg['data'])
 
 
 def get_monitor_data(
@@ -66,7 +66,7 @@ def get_monitor_data(
 
 
 def data_to_tof(
-    da: ConfiguredReducibleData[ScatteringRunType],
+    da: RawDetectorData[ScatteringRunType],
 ) -> TofData[ScatteringRunType]:
     """Dummy conversion of data to time-of-flight data.
     The data already has a time-of-flight coordinate."""
@@ -74,7 +74,7 @@ def data_to_tof(
 
 
 def monitor_to_tof(
-    da: ConfiguredReducibleMonitor[RunType, MonitorType],
+    da: RawMonitorData[RunType, MonitorType],
 ) -> TofMonitor[RunType, MonitorType]:
     """Dummy conversion of monitor data to time-of-flight data.
     The monitor data already has a time-of-flight coordinate."""

--- a/src/ess/loki/io.py
+++ b/src/ess/loki/io.py
@@ -9,11 +9,11 @@ from ess.reduce import nexus
 from ess.sans.types import (
     DetectorEventData,
     Filename,
-    LoadedNeXusDetector,
-    LoadedNeXusMonitor,
     MonitorEventData,
     MonitorType,
+    NeXusDetector,
     NeXusDetectorName,
+    NeXusMonitor,
     NeXusMonitorName,
     RawSample,
     RawSource,
@@ -37,7 +37,7 @@ def load_nexus_source(file_path: Filename[RunType]) -> RawSource[RunType]:
 
 def load_nexus_detector(
     file_path: Filename[RunType], detector_name: NeXusDetectorName
-) -> LoadedNeXusDetector[RunType]:
+) -> NeXusDetector[RunType]:
     # Events will be loaded later. Should we set something else as data instead, or
     # use different NeXus definitions to completely bypass the (empty) event load?
     dg = nexus.load_detector(
@@ -47,14 +47,14 @@ def load_nexus_detector(
     )
     # The name is required later, e.g., for determining logical detector shape
     dg['detector_name'] = detector_name
-    return LoadedNeXusDetector[RunType](dg)
+    return NeXusDetector[RunType](dg)
 
 
 def load_nexus_monitor(
     file_path: Filename[RunType],
     monitor_name: NeXusMonitorName[MonitorType],
-) -> LoadedNeXusMonitor[RunType, MonitorType]:
-    return LoadedNeXusMonitor[RunType, MonitorType](
+) -> NeXusMonitor[RunType, MonitorType]:
+    return NeXusMonitor[RunType, MonitorType](
         nexus.load_monitor(
             file_path=file_path,
             monitor_name=monitor_name,

--- a/src/ess/loki/io.py
+++ b/src/ess/loki/io.py
@@ -51,8 +51,7 @@ def load_nexus_detector(
 
 
 def load_nexus_monitor(
-    file_path: Filename[RunType],
-    monitor_name: NeXusMonitorName[MonitorType],
+    file_path: Filename[RunType], monitor_name: NeXusMonitorName[MonitorType]
 ) -> NeXusMonitor[RunType, MonitorType]:
     return NeXusMonitor[RunType, MonitorType](
         nexus.load_monitor(
@@ -71,8 +70,7 @@ def load_detector_event_data(
 
 
 def load_monitor_event_data(
-    file_path: Filename[RunType],
-    monitor_name: NeXusMonitorName[MonitorType],
+    file_path: Filename[RunType], monitor_name: NeXusMonitorName[MonitorType]
 ) -> MonitorEventData[RunType, MonitorType]:
     da = nexus.load_event_data(file_path=file_path, component_name=monitor_name)
     return MonitorEventData[RunType, MonitorType](da)

--- a/src/ess/loki/io.py
+++ b/src/ess/loki/io.py
@@ -40,9 +40,10 @@ def load_nexus_detector(
 ) -> LoadedNeXusDetector[RunType]:
     # Events will be loaded later. Should we set something else as data instead, or
     # use different NeXus definitions to completely bypass the (empty) event load?
-    sel = {'event_time_zero': slice(0, 0)}
     dg = nexus.load_detector(
-        file_path=file_path, detector_name=detector_name, selection=sel
+        file_path=file_path,
+        detector_name=detector_name,
+        selection={'event_time_zero': slice(0, 0)},
     )
     # The name is required later, e.g., for determining logical detector shape
     dg['detector_name'] = detector_name
@@ -54,7 +55,11 @@ def load_nexus_monitor(
     monitor_name: NeXusMonitorName[MonitorType],
 ) -> LoadedNeXusMonitor[RunType, MonitorType]:
     return LoadedNeXusMonitor[RunType, MonitorType](
-        nexus.load_monitor(file_path=file_path, monitor_name=monitor_name)
+        nexus.load_monitor(
+            file_path=file_path,
+            monitor_name=monitor_name,
+            selection={'event_time_zero': slice(0, 0)},
+        )
     )
 
 

--- a/src/ess/loki/workflow.py
+++ b/src/ess/loki/workflow.py
@@ -4,10 +4,10 @@ import sciline
 import scipp as sc
 import scippnexus as snx
 from ess.loki.general import (
+    assemble_monitor_data,
     get_monitor_data,
     get_source_position,
     monitor_to_tof,
-    patch_monitor_data,
 )
 from ess.loki.io import load_nexus_monitor, load_nexus_source
 from ess.reduce.nexus.json_nexus import JSONGroup
@@ -82,7 +82,7 @@ class LoKiMonitorWorkflow:
             load_nexus_source,
             get_source_position,
             get_monitor_data,
-            patch_monitor_data,
+            assemble_monitor_data,
             monitor_to_tof,
             sans_monitor,
             monitor_to_wavelength,

--- a/src/ess/sans/conversions.py
+++ b/src/ess/sans/conversions.py
@@ -11,8 +11,6 @@ from scippneutron.conversion.graph import beamline, tof
 
 from .common import mask_range
 from .types import (
-    BeamCenter,
-    CalibratedMaskedData,
     CleanQ,
     CleanQxy,
     CleanWavelength,
@@ -153,24 +151,11 @@ def monitor_to_wavelength(
     )
 
 
-def calibrate_positions(
-    detector: MaskedData[ScatteringRunType], beam_center: BeamCenter
-) -> CalibratedMaskedData[ScatteringRunType]:
-    """
-    Calibrate pixel positions.
-
-    Currently the only applied calibration is the beam-center offset.
-    """
-    detector = detector.copy(deep=False)
-    detector.coords['position'] = detector.coords['position'] - beam_center
-    return detector
-
-
 # TODO This demonstrates a problem: Transforming to wavelength should be possible
 # for RawData, MaskedData, ... no reason to restrict necessarily.
 # Would we be fine with just choosing on option, or will this get in the way for users?
 def detector_to_wavelength(
-    detector: CalibratedMaskedData[ScatteringRunType],
+    detector: MaskedData[ScatteringRunType],
     graph: ElasticCoordTransformGraph,
 ) -> CleanWavelength[ScatteringRunType, Numerator]:
     return CleanWavelength[ScatteringRunType, Numerator](
@@ -227,7 +212,6 @@ def compute_Qxy(
 providers = (
     sans_elastic,
     sans_monitor,
-    calibrate_positions,
     monitor_to_wavelength,
     detector_to_wavelength,
     mask_wavelength,

--- a/src/ess/sans/masking.py
+++ b/src/ess/sans/masking.py
@@ -13,14 +13,15 @@ from .types import (
     MaskedData,
     MaskedDetectorIDs,
     PixelMaskFilename,
+    RawData,
     SampleRun,
     ScatteringRunType,
     TofData,
 )
 
 
-def get_detector_ids_from_sample_run(data: TofData[SampleRun]) -> DetectorIDs:
-    """Extract detector IDs from sample run."""
+def get_detector_ids_from_detector(data: RawData[SampleRun]) -> DetectorIDs:
+    """Extract detector IDs from a detector."""
     return DetectorIDs(
         data.coords[
             'detector_number' if 'detector_number' in data.coords else 'detector_id'
@@ -65,7 +66,7 @@ def apply_pixel_masks(
 
 
 providers = (
-    get_detector_ids_from_sample_run,
+    get_detector_ids_from_detector,
     to_detector_mask,
     apply_pixel_masks,
 )

--- a/src/ess/sans/masking.py
+++ b/src/ess/sans/masking.py
@@ -13,14 +13,14 @@ from .types import (
     MaskedData,
     MaskedDetectorIDs,
     PixelMaskFilename,
-    RawData,
+    RawDetector,
     SampleRun,
     ScatteringRunType,
     TofData,
 )
 
 
-def get_detector_ids_from_detector(data: RawData[SampleRun]) -> DetectorIDs:
+def get_detector_ids_from_detector(data: RawDetector[SampleRun]) -> DetectorIDs:
     """Extract detector IDs from a detector."""
     return DetectorIDs(
         data.coords[

--- a/src/ess/sans/normalization.py
+++ b/src/ess/sans/normalization.py
@@ -5,19 +5,21 @@ from ess.reduce.uncertainty import UncertaintyBroadcastMode, broadcast_uncertain
 from scipp.core import concepts
 
 from .types import (
-    CalibratedMaskedData,
+    CalibratedDetector,
     CleanDirectBeam,
     CleanMonitor,
     CleanSummedQ,
     CleanSummedQxy,
     CleanWavelength,
     Denominator,
+    DetectorMasks,
     DetectorPixelShape,
     EmptyBeamRun,
     Incident,
     IofQ,
     IofQxy,
     LabFrameTransform,
+    MaskedSolidAngle,
     NormWavelengthTerm,
     Numerator,
     ProcessedWavelengthBands,
@@ -33,7 +35,7 @@ from .types import (
 
 
 def solid_angle(
-    data: CalibratedMaskedData[ScatteringRunType],
+    data: CalibratedDetector[ScatteringRunType],
     pixel_shape: DetectorPixelShape[ScatteringRunType],
     transform: LabFrameTransform[ScatteringRunType],
 ) -> SolidAngle[ScatteringRunType]:
@@ -79,6 +81,13 @@ def solid_angle(
             prototype=data, data=omega, dim=set(data.dims) - set(omega.dims)
         )
     )
+
+
+def mask_solid_angle(
+    solid_angle: SolidAngle[ScatteringRunType],
+    masks: DetectorMasks,
+) -> MaskedSolidAngle[ScatteringRunType]:
+    return MaskedSolidAngle[ScatteringRunType](solid_angle.assign_masks(masks))
 
 
 def _approximate_solid_angle_for_cylinder_shaped_pixel_of_detector(
@@ -219,7 +228,7 @@ def iofq_norm_wavelength_term(
 
 def iofq_denominator(
     wavelength_term: NormWavelengthTerm[ScatteringRunType],
-    solid_angle: SolidAngle[ScatteringRunType],
+    solid_angle: MaskedSolidAngle[ScatteringRunType],
     uncertainties: UncertaintyBroadcastMode,
 ) -> CleanWavelength[ScatteringRunType, Denominator]:
     """
@@ -452,4 +461,5 @@ providers = (
     normalize_qxy,
     process_wavelength_bands,
     solid_angle,
+    mask_solid_angle,
 )

--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -217,12 +217,12 @@ class SolidAngle(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
     """Solid angle of detector pixels seen from sample position"""
 
 
-class LoadedNeXusDetector(sciline.Scope[RunType, sc.DataGroup], sc.DataGroup):
+class NeXusDetector(sciline.Scope[RunType, sc.DataGroup], sc.DataGroup):
     """Detector data, loaded from a NeXus file, containing not only neutron events
     but also pixel shape information, transformations, ..."""
 
 
-class LoadedNeXusMonitor(
+class NeXusMonitor(
     sciline.ScopeTwoParams[RunType, MonitorType, sc.DataGroup], sc.DataGroup
 ):
     """Monitor data loaded from a NeXus file, containing not only neutron events
@@ -239,13 +239,11 @@ class MonitorEventData(
     """Event data loaded from a monitor in a NeXus file"""
 
 
-class RawData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
-    """Raw detector data"""
+class RawDetector(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
+    """Raw detector data component extracted from :py:class:`NeXusDetector`"""
 
 
-class ConfiguredReducibleData(
-    sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray
-):
+class RawDetectorData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
     """Raw event data where variances and necessary coordinates
     (e.g. sample and source position) have been added, and where optionally some
     user configuration was applied to some of the coordinates."""
@@ -342,7 +340,7 @@ class RawMonitor(
     """Raw monitor data"""
 
 
-class ConfiguredReducibleMonitor(
+class RawMonitorData(
     sciline.ScopeTwoParams[RunType, MonitorType, sc.DataArray], sc.DataArray
 ):
     """Raw monitor data where variances and necessary coordinates

--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -217,6 +217,10 @@ class SolidAngle(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
     """Solid angle of detector pixels seen from sample position"""
 
 
+class MaskedSolidAngle(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
+    """Same as :py:class:`SolidAngle`, but with pixel masks applied"""
+
+
 class NeXusDetector(sciline.Scope[RunType, sc.DataGroup], sc.DataGroup):
     """Detector data, loaded from a NeXus file, containing not only neutron events
     but also pixel shape information, transformations, ..."""
@@ -240,13 +244,15 @@ class MonitorEventData(
 
 
 class RawDetector(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
-    """Raw detector data component extracted from :py:class:`NeXusDetector`"""
+    """Raw detector component extracted from :py:class:`NeXusDetector`"""
 
 
-class RawDetectorData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
-    """Raw event data where variances and necessary coordinates
-    (e.g. sample and source position) have been added, and where optionally some
-    user configuration was applied to some of the coordinates."""
+class CalibratedDetector(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
+    """Calibrated version of raw detector"""
+
+
+class DetectorData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
+    """Calibrated detector with added raw event data"""
 
 
 class TofData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
@@ -264,12 +270,6 @@ PixelMask = NewType('PixelMask', sc.Variable)
 
 class MaskedData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
     """Raw data with pixel-specific masks applied"""
-
-
-class CalibratedMaskedData(
-    sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray
-):
-    """Raw data with pixel-specific masks applied and calibrated pixel positions"""
 
 
 class NormWavelengthTerm(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):

--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -229,6 +229,16 @@ class LoadedNeXusMonitor(
     but also transformations, ..."""
 
 
+class DetectorEventData(sciline.Scope[RunType, sc.DataArray], sc.DataArray):
+    """Event data loaded from a detector in a NeXus file"""
+
+
+class MonitorEventData(
+    sciline.ScopeTwoParams[RunType, MonitorType, sc.DataArray], sc.DataArray
+):
+    """Event data loaded from a monitor in a NeXus file"""
+
+
 class RawData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
     """Raw detector data"""
 

--- a/tests/isissans/sans2d_reduction_test.py
+++ b/tests/isissans/sans2d_reduction_test.py
@@ -24,7 +24,7 @@ from ess.sans.types import (
     NeXusMonitorName,
     NonBackgroundWavelengthRange,
     QBins,
-    RawData,
+    RawDetector,
     ReturnEvents,
     SampleRun,
     SolidAngle,
@@ -189,7 +189,7 @@ def as_dict(funcs: list[Callable[..., type]]) -> dict:
 
 
 def pixel_dependent_direct_beam(
-    filename: DirectBeamFilename, shape: RawData[SampleRun]
+    filename: DirectBeamFilename, shape: RawDetector[SampleRun]
 ) -> DirectBeam:
     direct_beam = isis.data.load_tutorial_direct_beam(filename)
     sizes = {'spectrum': shape.sizes['spectrum'], **direct_beam.sizes}
@@ -243,7 +243,7 @@ def test_beam_center_finder_without_direct_beam_reproduces_verified_result():
 
 def test_beam_center_can_get_closer_to_verified_result_with_low_counts_mask():
     def low_counts_mask(
-        sample: RawData[SampleRun],
+        sample: RawDetector[SampleRun],
         low_counts_threshold: sans2d.LowCountThreshold,
     ) -> sans2d.SampleHolderMask:
         return sans2d.SampleHolderMask(sample.hist().data < low_counts_threshold)
@@ -321,9 +321,9 @@ def test_workflow_runs_without_gravity_if_beam_center_is_provided():
     params = make_params()
     params[CorrectForGravity] = False
     pipeline = sciline.Pipeline(sans2d_providers(), params=params)
-    da = pipeline.compute(RawData[SampleRun])
+    da = pipeline.compute(RawDetector[SampleRun])
     del da.coords['gravity']
-    pipeline[RawData[SampleRun]] = da
+    pipeline[RawDetector[SampleRun]] = da
     pipeline[BeamCenter] = MANTID_BEAM_CENTER
     result = pipeline.compute(BackgroundSubtractedIofQ)
     assert result.dims == ('Q',)

--- a/tests/isissans/sans2d_reduction_test.py
+++ b/tests/isissans/sans2d_reduction_test.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
-from collections.abc import Callable
-
 import pytest
 import sciline
 import scipp as sc
@@ -71,6 +69,7 @@ def make_params() -> dict:
     params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound
     params[ReturnEvents] = False
     params[DimsToKeep] = ()
+    params[BeamCenter] = sc.vector([0, 0, 0], unit='m')
 
     return params
 
@@ -86,7 +85,6 @@ def sans2d_providers():
             isis.data.load_tutorial_run,
             isis.data.transmission_from_background_run,
             isis.data.transmission_from_sample_run,
-            sans.beam_center_finder.beam_center_from_center_of_mass,
         )
     )
 
@@ -121,6 +119,7 @@ def test_pipeline_can_compute_background_subtracted_IofQ_in_wavelength_bands():
 def test_pipeline_wavelength_bands_is_optional():
     params = make_params()
     pipeline = sciline.Pipeline(sans2d_providers(), params=params)
+    pipeline[BeamCenter] = sans.beam_center_from_center_of_mass(pipeline)
     noband = pipeline.compute(BackgroundSubtractedIofQ)
     assert pipeline.compute(WavelengthBands) is None
     band = sc.linspace('wavelength', 2.0, 16.0, num=2, unit='angstrom')
@@ -134,6 +133,7 @@ def test_workflow_is_deterministic():
     params = make_params()
     params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.drop
     pipeline = sciline.Pipeline(sans2d_providers(), params=params)
+    pipeline[BeamCenter] = sans.beam_center_from_center_of_mass(pipeline)
     # This is Sciline's default scheduler, but we want to be explicit here
     scheduler = sciline.scheduler.DaskScheduler()
     graph = pipeline.get(IofQ[SampleRun], scheduler=scheduler)
@@ -179,15 +179,6 @@ def test_pipeline_can_compute_intermediate_results():
     assert result.dims == ('spectrum',)
 
 
-# TODO See scipp/sciline#57 for plans on a builtin way to do this
-def as_dict(funcs: list[Callable[..., type]]) -> dict:
-    from typing import get_type_hints
-
-    return dict(
-        zip([get_type_hints(func)['return'] for func in funcs], funcs, strict=True)
-    )
-
-
 def pixel_dependent_direct_beam(
     filename: DirectBeamFilename, shape: RawDetector[SampleRun]
 ) -> DirectBeam:
@@ -203,9 +194,9 @@ def pixel_dependent_direct_beam(
 def test_pixel_dependent_direct_beam_is_supported(uncertainties):
     params = make_params()
     params[UncertaintyBroadcastMode] = uncertainties
-    providers = as_dict(sans2d_providers())
-    providers[DirectBeam] = pixel_dependent_direct_beam
-    pipeline = sciline.Pipeline(providers.values(), params=params)
+    pipeline = sciline.Pipeline(sans2d_providers(), params=params)
+    pipeline.insert(pixel_dependent_direct_beam)
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     result = pipeline.compute(BackgroundSubtractedIofQ)
     assert result.dims == ('Q',)
 
@@ -217,27 +208,31 @@ def test_beam_center_from_center_of_mass_is_close_to_verified_result():
     params = make_params()
     providers = sans2d_providers()
     pipeline = sciline.Pipeline(providers, params=params)
-    center = pipeline.compute(BeamCenter)
+    center = sans.beam_center_from_center_of_mass(pipeline)
     # This is the result obtained from Mantid, using the full IofQ
     # calculation. The difference is about 3 mm in X or Y, probably due to a bias
     # introduced by the sample holder, which the center-of-mass approach cannot ignore.
     assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(3e-3, unit='m'))
 
 
+def test_beam_center_from_center_of_mass_independent_of_set_beam_center():
+    params = make_params()
+    providers = sans2d_providers()
+    pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0.1, -0.1, 0], unit='m')
+    center = sans.beam_center_from_center_of_mass(pipeline)
+    assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(3e-3, unit='m'))
+
+
 def test_beam_center_finder_without_direct_beam_reproduces_verified_result():
     params = make_params()
-    params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(
-        'Q', 0.02, 0.3, 71, unit='1/angstrom'
-    )
     del params[DirectBeamFilename]
     providers = sans2d_providers()
-    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
-    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
-    pipeline[sans.beam_center_finder.BeamCenterFinderMinimizer] = None
-    pipeline[sans.beam_center_finder.BeamCenterFinderTolerance] = None
     pipeline[DirectBeam] = None
-    center = pipeline.compute(BeamCenter)
+    center = sans.beam_center_finder.beam_center_from_iofq(
+        workflow=pipeline, q_bins=sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
+    )
     assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(2e-3, unit='m'))
 
 
@@ -250,52 +245,54 @@ def test_beam_center_can_get_closer_to_verified_result_with_low_counts_mask():
 
     params = make_params()
     params[sans2d.LowCountThreshold] = sc.scalar(80.0, unit='counts')
-    params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(
-        'Q', 0.02, 0.3, 71, unit='1/angstrom'
-    )
     del params[DirectBeamFilename]
     providers = sans2d_providers()
     providers.remove(sans2d.sample_holder_mask)
-    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
-    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     providers.append(low_counts_mask)
     pipeline = sciline.Pipeline(providers, params=params)
-    pipeline[sans.beam_center_finder.BeamCenterFinderMinimizer] = None
-    pipeline[sans.beam_center_finder.BeamCenterFinderTolerance] = None
     pipeline[DirectBeam] = None
-    center = pipeline.compute(BeamCenter)
+    q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
+    center = sans.beam_center_finder.beam_center_from_iofq(
+        workflow=pipeline, q_bins=q_bins
+    )
     assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(5e-4, unit='m'))
 
 
 def test_beam_center_finder_works_with_direct_beam():
     params = make_params()
-    params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(
-        'Q', 0.02, 0.3, 71, unit='1/angstrom'
-    )
     providers = sans2d_providers()
-    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
-    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
-    pipeline[sans.beam_center_finder.BeamCenterFinderMinimizer] = None
-    pipeline[sans.beam_center_finder.BeamCenterFinderTolerance] = None
-    center_with_direct_beam = pipeline.compute(BeamCenter)
+    q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
+    center_with_direct_beam = sans.beam_center_finder.beam_center_from_iofq(
+        workflow=pipeline, q_bins=q_bins
+    )
+    assert sc.allclose(
+        center_with_direct_beam, MANTID_BEAM_CENTER, atol=sc.scalar(2e-3, unit='m')
+    )
+
+
+def test_beam_center_finder_independent_of_set_beam_center():
+    params = make_params()
+    providers = sans2d_providers()
+    pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0.1, -0.1, 0], unit='m')
+    q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
+    center_with_direct_beam = sans.beam_center_finder.beam_center_from_iofq(
+        workflow=pipeline, q_bins=q_bins
+    )
     assert sc.allclose(
         center_with_direct_beam, MANTID_BEAM_CENTER, atol=sc.scalar(2e-3, unit='m')
     )
 
 
 def test_beam_center_finder_works_with_pixel_dependent_direct_beam():
+    q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
     params = make_params()
-    params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(
-        'Q', 0.02, 0.3, 71, unit='1/angstrom'
-    )
     providers = sans2d_providers()
-    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
-    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
-    pipeline[sans.beam_center_finder.BeamCenterFinderMinimizer] = None
-    pipeline[sans.beam_center_finder.BeamCenterFinderTolerance] = None
-    center_pixel_independent_direct_beam = pipeline.compute(BeamCenter)
+    center_pixel_independent_direct_beam = (
+        sans.beam_center_finder.beam_center_from_iofq(workflow=pipeline, q_bins=q_bins)
+    )
 
     direct_beam = pipeline.compute(DirectBeam)
     pixel_dependent_direct_beam = direct_beam.broadcast(
@@ -306,14 +303,12 @@ def test_beam_center_finder_works_with_pixel_dependent_direct_beam():
     ).copy()
 
     providers = sans2d_providers()
-    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
-    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
-    pipeline[sans.beam_center_finder.BeamCenterFinderMinimizer] = None
-    pipeline[sans.beam_center_finder.BeamCenterFinderTolerance] = None
     pipeline[DirectBeam] = pixel_dependent_direct_beam
 
-    center = pipeline.compute(BeamCenter)
+    center = sans.beam_center_finder.beam_center_from_iofq(
+        workflow=pipeline, q_bins=q_bins
+    )
     assert sc.identical(center, center_pixel_independent_direct_beam)
 
 

--- a/tests/isissans/zoom_reduction_test.py
+++ b/tests/isissans/zoom_reduction_test.py
@@ -5,6 +5,7 @@ import scipp as sc
 from ess import isissans as isis
 from ess import sans
 from ess.sans.types import (
+    BeamCenter,
     CorrectForGravity,
     Filename,
     Incident,
@@ -63,13 +64,13 @@ def zoom_providers():
             isis.data.load_tutorial_run,
             isis.data.transmission_from_background_run,
             isis.data.transmission_from_sample_run,
-            sans.beam_center_finder.beam_center_from_center_of_mass,
         )
     )
 
 
 def test_can_create_pipeline():
     pipeline = sciline.Pipeline(zoom_providers(), params=make_params())
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, isis.data.zoom_tutorial_mask_filenames()
     )
@@ -78,6 +79,7 @@ def test_can_create_pipeline():
 
 def test_pipeline_can_compute_IofQ():
     pipeline = sciline.Pipeline(zoom_providers(), params=make_params())
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, isis.data.zoom_tutorial_mask_filenames()
     )
@@ -87,6 +89,7 @@ def test_pipeline_can_compute_IofQ():
 
 def test_pipeline_can_compute_IofQxQy():
     pipeline = sciline.Pipeline(zoom_providers(), params=make_params())
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, isis.data.zoom_tutorial_mask_filenames()
     )

--- a/tests/loki/common.py
+++ b/tests/loki/common.py
@@ -55,7 +55,7 @@ def make_params(no_masks: bool = True) -> dict:
     return params
 
 
-def loki_providers_no_beam_center_finder() -> list[Callable]:
+def loki_providers() -> list[Callable]:
     from ess.isissans.io import read_xml_detector_masking
 
     return list(
@@ -66,10 +66,3 @@ def loki_providers_no_beam_center_finder() -> list[Callable]:
             loki.io.dummy_load_sample,
         )
     )
-
-
-def loki_providers() -> list[Callable]:
-    return [
-        *loki_providers_no_beam_center_finder(),
-        sans.beam_center_finder.beam_center_from_center_of_mass,
-    ]

--- a/tests/loki/directbeam_test.py
+++ b/tests/loki/directbeam_test.py
@@ -6,7 +6,13 @@ from pathlib import Path
 import sciline
 import scipp as sc
 from ess import loki, sans
-from ess.sans.types import DimsToKeep, QBins, WavelengthBands, WavelengthBins
+from ess.sans.types import (
+    BeamCenter,
+    DimsToKeep,
+    QBins,
+    WavelengthBands,
+    WavelengthBins,
+)
 from scipp.scipy.interpolate import interp1d
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -30,6 +36,7 @@ def test_can_compute_direct_beam_for_all_pixels():
     )
     providers = loki_providers()
     pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     I0 = _get_I0(qbins=params[QBins])
 
     results = sans.direct_beam(workflow=pipeline, I0=I0, niter=4)
@@ -59,6 +66,7 @@ def test_can_compute_direct_beam_with_overlapping_wavelength_bands():
 
     providers = loki_providers()
     pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     I0 = _get_I0(qbins=params[QBins])
 
     results = sans.direct_beam(workflow=pipeline, I0=I0, niter=4)
@@ -84,6 +92,7 @@ def test_can_compute_direct_beam_per_layer():
     params[DimsToKeep] = ['layer']
     providers = loki_providers()
     pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     I0 = _get_I0(qbins=params[QBins])
 
     results = sans.direct_beam(workflow=pipeline, I0=I0, niter=4)
@@ -111,6 +120,7 @@ def test_can_compute_direct_beam_per_layer_and_straw():
     params[DimsToKeep] = ('layer', 'straw')
     providers = loki_providers()
     pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     I0 = _get_I0(qbins=params[QBins])
 
     results = sans.direct_beam(workflow=pipeline, I0=I0, niter=4)


### PR DESCRIPTION
This addition is related to the new approach discussed in scipp/beamlime#215. ~It depends on a release of scipp/essreduce#53, i.e., CI will fail for now.~

Edit: ~converted to draft, since I found one more dependency on event data that should not be there (for solid angle).~ -> This is fixed by the follow-up #155 (now merged into this branch). -> Fixes #154.
Also closes #39, closes #62.

By loading NXevent_data separately from the containing NXdetector or NXmonitor we increase flexibility, reduce overhead, and continue paving the path towards chunked processing of large files.

Before:

![Image](https://github.com/user-attachments/assets/fa312834-5e77-40f3-a9d2-89d8027b35c5)

After:

![image](https://github.com/user-attachments/assets/1b693751-1cdd-4d5b-9d31-ba19892e9b4c)

Notes:

- By getting the detector IDs from the `RawData[SampleRun]`, which is now the "empty" detector with no events, masks can be loaded and processed without loading potentially huge amounts of events. Even if the events will be loaded anyway this will improve parallelism, and will avoid reprocessing of masks if the event data changes.
- Chunking loading of the event data (using Sciline's map-reduce) with the "after" graph will only load new events, which is also what we need to do for live-reduction. Other detector information as well as masks can be reused. In short, the graph is "wider", which is better.


