### PR TITLE
Workflow dependency restructure

### DIFF
--- a/docs/user-guide/common/beam-center-finder.ipynb
+++ b/docs/user-guide/common/beam-center-finder.ipynb
@@ -304,10 +304,10 @@
    "outputs": [],
    "source": [
     "workflow[Filename[SampleRun]] = isis.data.sans2d_tutorial_sample_run()\n",
-    "workflow[RawDetector[SampleRun]] = workflow.compute(RawDetector[SampleRun])[\n",
-    "    'spectrum', :61440\n",
-    "]\n",
-    "workflow[DetectorMasks] = masked.masks"
+    "detector = workflow.compute(RawDetector[SampleRun])['spectrum', :61440].assign_masks(\n",
+    "    masked.masks\n",
+    ")\n",
+    "workflow[RawDetector[SampleRun]] = detector"
    ]
   },
   {
@@ -440,14 +440,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "workflow = workflow.copy()\n",
+    "workflow[QBins] = q_bins\n",
+    "workflow[ReturnEvents] = False\n",
+    "workflow[DimsToKeep] = ()\n",
+    "workflow[WavelengthMask] = None\n",
+    "workflow[WavelengthBands] = None\n",
     "kwargs = dict(  # noqa: C408\n",
-    "    data=masked,\n",
+    "    workflow=workflow,\n",
+    "    detector=detector,\n",
     "    norm=workflow.compute(NormWavelengthTerm[SampleRun]),\n",
-    "    graph=workflow.compute(sans.conversions.ElasticCoordTransformGraph),\n",
-    "    q_bins=workflow.compute(sans.beam_center_finder.BeamCenterFinderQBins),\n",
-    "    wavelength_bins=workflow.compute(WavelengthBins),\n",
-    "    transform=workflow.compute(LabFrameTransform[SampleRun]),\n",
-    "    pixel_shape=workflow.compute(DetectorPixelShape[SampleRun]),\n",
     ")"
    ]
   },

--- a/docs/user-guide/common/beam-center-finder.ipynb
+++ b/docs/user-guide/common/beam-center-finder.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "raw = workflow.compute(RawData[SampleRun])['spectrum', :61440]\n",
+    "raw = workflow.compute(RawDetector[SampleRun])['spectrum', :61440]\n",
     "\n",
     "p = isis.plot_flat_detector_xy(raw.hist(), norm='log')\n",
     "p.ax.plot(0, 0, '+', color='k', ms=10)\n",
@@ -128,6 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "workflow[BeamCenter] = sc.vector(value=[0, 0, 0], unit='m')\n",
     "masked = workflow.compute(MaskedData[SampleRun])['spectrum', :61440].copy()\n",
     "masked.masks['low_counts'] = masked.hist().data < sc.scalar(80.0, unit='counts')\n",
     "\n",
@@ -156,9 +157,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Insert the provider that computes the center-of-mass of the pixels\n",
-    "workflow.insert(sans.beam_center_finder.beam_center_from_center_of_mass)\n",
-    "workflow.visualize(BeamCenter, graph_attr={'rankdir': 'LR'})"
+    "# The center-of-mass approach is based on the MaskedData\n",
+    "workflow.visualize(MaskedData[SampleRun])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7aac9d0",
+   "metadata": {},
+   "source": [
+    "We use the workflow to fill in the required arguments and call the function:"
    ]
   },
   {
@@ -168,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "com = workflow.compute(BeamCenter)\n",
+    "com = workflow.bind_and_call(sans.beam_center_finder.beam_center_from_center_of_mass)\n",
     "com"
    ]
   },
@@ -245,11 +253,7 @@
     "workflow = isis.sans2d.Sans2dTutorialWorkflow()\n",
     "# For real data use:\n",
     "# workflow = isis.sans2d.Sans2dWorkflow()\n",
-    "\n",
-    "workflow.insert(isis.data.transmission_from_sample_run)\n",
-    "# Insert the provider that computes the center from I(Q) curves\n",
-    "workflow.insert(sans.beam_center_finder.beam_center_from_iofq)\n",
-    "workflow.visualize(BeamCenter, graph_attr={'rankdir': 'LR'})"
+    "workflow.insert(isis.data.transmission_from_sample_run)"
    ]
   },
   {
@@ -280,12 +284,8 @@
     "\n",
     "workflow[CorrectForGravity] = True\n",
     "workflow[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.upper_bound\n",
-    "workflow[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(\n",
-    "    'Q', 0.02, 0.25, 71, unit='1/angstrom'\n",
-    ")\n",
-    "workflow[sans.beam_center_finder.BeamCenterFinderMinimizer] = None\n",
-    "workflow[sans.beam_center_finder.BeamCenterFinderTolerance] = None\n",
-    "workflow[DirectBeam] = None"
+    "workflow[DirectBeam] = None\n",
+    "workflow[isis.sans2d.LowCountThreshold] = sc.scalar(-1, unit=\"counts\")"
    ]
   },
   {
@@ -293,7 +293,7 @@
    "id": "641be8e9",
    "metadata": {},
    "source": [
-    "Finally, we set the data to be used, including overriding with data that contains the new mask defined earlier:"
+    "Finally, we set the data to be used, including overriding with the new mask defined earlier:"
    ]
   },
   {
@@ -304,7 +304,10 @@
    "outputs": [],
    "source": [
     "workflow[Filename[SampleRun]] = isis.data.sans2d_tutorial_sample_run()\n",
-    "workflow[MaskedData[SampleRun]] = masked"
+    "workflow[RawDetector[SampleRun]] = workflow.compute(RawDetector[SampleRun])[\n",
+    "    'spectrum', :61440\n",
+    "]\n",
+    "workflow[DetectorMasks] = masked.masks"
    ]
   },
   {
@@ -322,11 +325,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c087798a-fc33-4292-924c-eed8e3baf36a",
+   "id": "329a0cd9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "iofq_center = workflow.compute(BeamCenter)\n",
+    "q_bins = sc.linspace('Q', 0.02, 0.25, 71, unit='1/angstrom')\n",
+    "workflow[BeamCenter] = sc.vector([0, 0, 0], unit='m')\n",
+    "iofq_center = sans.beam_center_finder.beam_center_from_iofq(\n",
+    "    workflow=workflow, q_bins=q_bins\n",
+    ")\n",
     "iofq_center"
    ]
   },
@@ -628,7 +635,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/common/beam-center-finder.ipynb
+++ b/docs/user-guide/common/beam-center-finder.ipynb
@@ -176,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "com = workflow.bind_and_call(sans.beam_center_finder.beam_center_from_center_of_mass)\n",
+    "com = sans.beam_center_finder.beam_center_from_center_of_mass(workflow)\n",
     "com"
    ]
   },

--- a/docs/user-guide/isis/sans2d.ipynb
+++ b/docs/user-guide/isis/sans2d.ipynb
@@ -182,8 +182,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow[BeamCenter] = sc.vector([0, 0, 0], unit='m')\n",
-    "center = workflow.bind_and_call(sans.beam_center_from_center_of_mass)\n",
+    "center = sans.beam_center_from_center_of_mass(workflow)\n",
     "center"
    ]
   },

--- a/docs/user-guide/isis/sans2d.ipynb
+++ b/docs/user-guide/isis/sans2d.ipynb
@@ -72,8 +72,7 @@
    "outputs": [],
    "source": [
     "workflow.insert(isis.data.transmission_from_background_run)\n",
-    "workflow.insert(isis.data.transmission_from_sample_run)\n",
-    "workflow.insert(sans.beam_center_from_center_of_mass)"
+    "workflow.insert(isis.data.transmission_from_sample_run)"
    ]
   },
   {
@@ -165,6 +164,45 @@
     "workflow[Filename[SampleRun]] = isis.data.sans2d_tutorial_sample_run()\n",
     "workflow[Filename[BackgroundRun]] = isis.data.sans2d_tutorial_background_run()\n",
     "workflow[Filename[EmptyBeamRun]] = isis.data.sans2d_tutorial_empty_beam_run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "981f1f28",
+   "metadata": {},
+   "source": [
+    "The beam center is not set yet.\n",
+    "Unless we have a previously computed value, we can do so now:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "064f87a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow[BeamCenter] = sc.vector([0, 0, 0], unit='m')\n",
+    "center = workflow.bind_and_call(sans.beam_center_from_center_of_mass)\n",
+    "center"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d7ce61a",
+   "metadata": {},
+   "source": [
+    "Remember to update the workflow with the new center:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a4c43f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow[BeamCenter] = center"
    ]
   },
   {
@@ -391,7 +429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/isis/zoom.ipynb
+++ b/docs/user-guide/isis/zoom.ipynb
@@ -187,8 +187,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow[BeamCenter] = sc.vector([0, 0, 0], unit='m')\n",
-    "workflow[BeamCenter] = workflow.bind_and_call(sans.beam_center_from_center_of_mass)"
+    "workflow[BeamCenter] = sans.beam_center_from_center_of_mass(workflow)"
    ]
   },
   {

--- a/docs/user-guide/isis/zoom.ipynb
+++ b/docs/user-guide/isis/zoom.ipynb
@@ -71,8 +71,7 @@
    "metadata": {},
    "source": [
     "We can insert steps for configuring the workflow.\n",
-    "In this case, we would like to use the transmission monitor from the regular background and sample runs since there was no separate transmission run.\n",
-    "We also want to compute the beam center using a simple center-of-mass estimation:"
+    "In this case, we would like to use the transmission monitor from the regular background and sample runs since there was no separate transmission run."
    ]
   },
   {
@@ -83,8 +82,7 @@
    "outputs": [],
    "source": [
     "workflow.insert(isis.data.transmission_from_background_run)\n",
-    "workflow.insert(isis.data.transmission_from_sample_run)\n",
-    "workflow.insert(sans.beam_center_from_center_of_mass)"
+    "workflow.insert(isis.data.transmission_from_sample_run)"
    ]
   },
   {
@@ -175,6 +173,30 @@
    "metadata": {},
    "source": [
     "## Use the workflow\n",
+    "\n",
+    "### Set or compute the beam center\n",
+    "\n",
+    "The beam center is not set by default.\n",
+    "We can either set it to a known value, or compute it from the data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "568cd4be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow[BeamCenter] = sc.vector([0, 0, 0], unit='m')\n",
+    "workflow[BeamCenter] = workflow.bind_and_call(sans.beam_center_from_center_of_mass)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13ddd330",
+   "metadata": {},
+   "source": [
+    "\n",
     "\n",
     "### Compute final result\n",
     "\n",

--- a/docs/user-guide/loki/loki-direct-beam.ipynb
+++ b/docs/user-guide/loki/loki-direct-beam.ipynb
@@ -190,36 +190,8 @@
     "and inserting the provider that will compute the beam center.\n",
     "\n",
     "For now, we compute the beam center only for the rear detector (named 'larmor_detector') but apply it to all banks (currently there is only one bank).\n",
-    "The beam center may need to be computed or applied differently to each bank, see [scipp/esssans#28](https://github.com/scipp/esssans/issues/28)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bdc15ab4-6ec6-4a29-81dc-1d00a8e890dc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bc_workflow = workflow.copy()\n",
-    "bc_workflow.insert(sans.beam_center_from_center_of_mass)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7cc2cf3b-973e-4425-93ea-deb30b12c956",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bc_workflow.visualize(BeamCenter, compact=True, graph_attr={'rankdir': 'LR'})"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b6bf5342-6768-4b65-882b-aefc9b583724",
-   "metadata": {},
-   "source": [
-    "We can now compute the value for the center"
+    "The beam center may need to be computed or applied differently to each bank, see [scipp/esssans#28](https://github.com/scipp/esssans/issues/28).\n",
+    "We set the initial beam center to the origin and then use a center-of-mass approach to refine it:"
    ]
   },
   {
@@ -229,7 +201,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "center = bc_workflow.compute(BeamCenter)\n",
+    "workflow[BeamCenter] = sc.vector([0, 0, 0], unit='m')\n",
+    "center = workflow.bind_and_call(sans.beam_center_from_center_of_mass)\n",
     "center"
    ]
   },
@@ -238,7 +211,7 @@
    "id": "0814805a-9611-4951-a015-c12ae254b099",
    "metadata": {},
    "source": [
-    "and set that value onto our original workflow"
+    "and set that value in our workflow"
    ]
   },
   {
@@ -639,7 +612,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/docs/user-guide/loki/loki-direct-beam.ipynb
+++ b/docs/user-guide/loki/loki-direct-beam.ipynb
@@ -191,7 +191,7 @@
     "\n",
     "For now, we compute the beam center only for the rear detector (named 'larmor_detector') but apply it to all banks (currently there is only one bank).\n",
     "The beam center may need to be computed or applied differently to each bank, see [scipp/esssans#28](https://github.com/scipp/esssans/issues/28).\n",
-    "We set the initial beam center to the origin and then use a center-of-mass approach to refine it:"
+    "We use a center-of-mass approach to find the beam center:"
    ]
   },
   {
@@ -201,8 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow[BeamCenter] = sc.vector([0, 0, 0], unit='m')\n",
-    "center = workflow.bind_and_call(sans.beam_center_from_center_of_mass)\n",
+    "center = sans.beam_center_from_center_of_mass(workflow)\n",
     "center"
    ]
   },

--- a/src/ess/isissans/components.py
+++ b/src/ess/isissans/components.py
@@ -6,9 +6,10 @@ import sciline
 import scipp as sc
 
 from ..sans.types import (
+    BeamCenter,
+    CalibratedDetector,
     MonitorType,
     RawDetector,
-    RawDetectorData,
     RawMonitor,
     RawMonitorData,
     RunType,
@@ -28,7 +29,8 @@ def apply_component_user_offsets_to_raw_data(
     data: RawDetector[ScatteringRunType],
     sample_offset: SampleOffset,
     detector_bank_offset: DetectorBankOffset,
-) -> RawDetectorData[ScatteringRunType]:
+    beam_center: BeamCenter,
+) -> CalibratedDetector[ScatteringRunType]:
     """Apply user offsets to raw data.
 
     Parameters
@@ -46,8 +48,11 @@ def apply_component_user_offsets_to_raw_data(
         unit=sample_pos.unit, copy=False
     )
     pos = data.coords['position']
-    data.coords['position'] = pos + detector_bank_offset.to(unit=pos.unit, copy=False)
-    return RawDetectorData[ScatteringRunType](data)
+    data.coords['user_position'] = pos + detector_bank_offset.to(
+        unit=pos.unit, copy=False
+    )
+    data.coords['position'] = data.coords['user_position'] - beam_center
+    return CalibratedDetector[ScatteringRunType](data)
 
 
 def apply_component_user_offsets_to_raw_monitor(

--- a/src/ess/isissans/components.py
+++ b/src/ess/isissans/components.py
@@ -25,11 +25,8 @@ SampleOffset = NewType('SampleOffset', sc.Variable)
 DetectorBankOffset = NewType('DetectorBankOffset', sc.Variable)
 
 
-def apply_component_user_offsets_to_raw_data(
-    data: RawDetector[ScatteringRunType],
-    sample_offset: SampleOffset,
-    detector_bank_offset: DetectorBankOffset,
-    beam_center: BeamCenter,
+def apply_beam_center(
+    data: RawDetector[ScatteringRunType], beam_center: BeamCenter
 ) -> CalibratedDetector[ScatteringRunType]:
     """Apply user offsets to raw data.
 
@@ -42,17 +39,9 @@ def apply_component_user_offsets_to_raw_data(
     detector_bank_offset:
         Detector bank offset.
     """
-    data = data.copy(deep=False)
-    sample_pos = data.coords['sample_position']
-    data.coords['sample_position'] = sample_pos + sample_offset.to(
-        unit=sample_pos.unit, copy=False
+    return CalibratedDetector[ScatteringRunType](
+        data.assign_coords(position=data.coords['position'] - beam_center)
     )
-    pos = data.coords['position']
-    data.coords['user_position'] = pos + detector_bank_offset.to(
-        unit=pos.unit, copy=False
-    )
-    data.coords['position'] = data.coords['user_position'] - beam_center
-    return CalibratedDetector[ScatteringRunType](data)
 
 
 def apply_component_user_offsets_to_raw_monitor(
@@ -74,6 +63,6 @@ def apply_component_user_offsets_to_raw_monitor(
 
 
 providers = (
-    apply_component_user_offsets_to_raw_data,
+    apply_beam_center,
     apply_component_user_offsets_to_raw_monitor,
 )

--- a/src/ess/isissans/general.py
+++ b/src/ess/isissans/general.py
@@ -7,7 +7,9 @@ Providers for the ISIS instruments.
 import scipp as sc
 
 from ..sans.types import (
+    CalibratedDetector,
     CorrectForGravity,
+    DetectorData,
     DetectorIDs,
     DetectorPixelShape,
     DimsToKeep,
@@ -17,7 +19,6 @@ from ..sans.types import (
     NeXusMonitorName,
     NonBackgroundWavelengthRange,
     RawDetector,
-    RawDetectorData,
     RawMonitor,
     RawMonitorData,
     RunNumber,
@@ -57,6 +58,13 @@ def get_detector_data(
     return RawDetector[RunType](dg['data'])
 
 
+def assemble_detector_data(
+    detector: CalibratedDetector[RunType],
+) -> DetectorData[RunType]:
+    """Dummy assembly of detector data, detector already contains neutron data."""
+    return DetectorData[RunType](detector)
+
+
 def get_monitor_data(
     dg: LoadedFileContents[RunType], nexus_name: NeXusMonitorName[MonitorType]
 ) -> RawMonitor[RunType, MonitorType]:
@@ -66,7 +74,7 @@ def get_monitor_data(
 
 
 def data_to_tof(
-    da: RawDetectorData[ScatteringRunType],
+    da: DetectorData[ScatteringRunType],
 ) -> TofData[ScatteringRunType]:
     """Dummy conversion of data to time-of-flight data.
     The data already has a time-of-flight coordinate."""
@@ -138,6 +146,7 @@ def get_detector_ids_from_sample_run(data: TofData[SampleRun]) -> DetectorIDs:
 
 
 providers = (
+    assemble_detector_data,
     get_detector_data,
     get_detector_ids_from_sample_run,
     get_monitor_data,

--- a/src/ess/isissans/general.py
+++ b/src/ess/isissans/general.py
@@ -54,8 +54,28 @@ def default_parameters() -> dict:
 
 def get_detector_data(
     dg: LoadedFileContents[RunType],
+    sample_offset: SampleOffset,
+    detector_bank_offset: DetectorBankOffset,
 ) -> RawDetector[RunType]:
-    return RawDetector[RunType](dg['data'])
+    """Get detector data and apply user offsets to raw data.
+
+    Parameters
+    ----------
+    dg:
+        Data loaded with Mantid and converted to Scipp.
+    sample_offset:
+        Sample offset.
+    detector_bank_offset:
+        Detector bank offset.
+    """
+    data = dg['data']
+    sample_pos = data.coords['sample_position']
+    sample_pos = sample_pos + sample_offset.to(unit=sample_pos.unit, copy=False)
+    pos = data.coords['position']
+    pos = pos + detector_bank_offset.to(unit=pos.unit, copy=False)
+    return RawDetector[RunType](
+        dg['data'].assign_coords(position=pos, sample_position=sample_pos)
+    )
 
 
 def assemble_detector_data(

--- a/src/ess/isissans/sans2d.py
+++ b/src/ess/isissans/sans2d.py
@@ -5,7 +5,7 @@ from typing import NewType
 import sciline
 import scipp as sc
 from ess.sans import providers as sans_providers
-from ess.sans.types import MaskedData, SampleRun, ScatteringRunType, TofData
+from ess.sans.types import CalibratedDetector, DetectorMasks, SampleRun
 
 from .data import load_tutorial_direct_beam, load_tutorial_run
 from .general import default_parameters
@@ -22,52 +22,52 @@ SampleHolderMask = NewType('SampleHolderMask', sc.Variable | None)
 """Sample holder mask"""
 
 
-def detector_edge_mask(sample: TofData[SampleRun]) -> DetectorEdgeMask:
+def detector_edge_mask(sample: CalibratedDetector[SampleRun]) -> DetectorEdgeMask:
     mask_edges = (
-        sc.abs(sample.coords['position'].fields.x) > sc.scalar(0.48, unit='m')
-    ) | (sc.abs(sample.coords['position'].fields.y) > sc.scalar(0.45, unit='m'))
+        sc.abs(sample.coords['user_position'].fields.x) > sc.scalar(0.48, unit='m')
+    ) | (sc.abs(sample.coords['user_position'].fields.y) > sc.scalar(0.45, unit='m'))
     return DetectorEdgeMask(mask_edges)
 
 
 def sample_holder_mask(
-    sample: TofData[SampleRun], low_counts_threshold: LowCountThreshold
+    sample: CalibratedDetector[SampleRun], low_counts_threshold: LowCountThreshold
 ) -> SampleHolderMask:
     summed = sample.hist()
     holder_mask = (
         (summed.data < low_counts_threshold)
-        & (sample.coords['position'].fields.x > sc.scalar(0, unit='m'))
-        & (sample.coords['position'].fields.x < sc.scalar(0.42, unit='m'))
-        & (sample.coords['position'].fields.y < sc.scalar(0.05, unit='m'))
-        & (sample.coords['position'].fields.y > sc.scalar(-0.15, unit='m'))
+        & (sample.coords['user_position'].fields.x > sc.scalar(0, unit='m'))
+        & (sample.coords['user_position'].fields.x < sc.scalar(0.42, unit='m'))
+        & (sample.coords['user_position'].fields.y < sc.scalar(0.05, unit='m'))
+        & (sample.coords['user_position'].fields.y > sc.scalar(-0.15, unit='m'))
     )
     return SampleHolderMask(holder_mask)
 
 
-def mask_detectors(
-    da: TofData[ScatteringRunType],
-    edge_mask: DetectorEdgeMask,
-    holder_mask: SampleHolderMask,
-) -> MaskedData[ScatteringRunType]:
-    """Apply pixel-specific masks to raw data.
+def to_detector_masks(
+    edge_mask: DetectorEdgeMask, holder_mask: SampleHolderMask
+) -> DetectorMasks:
+    """Gather detector masks.
+
+    Unlike :py:func:`ess.sans.masking.to_detector_mask`, this function does not rely on
+    mapping using a table of mask filenames. Instead it directly returns a dictionary
+    if multiple masks.
 
     Parameters
     ----------
-    da:
-        Raw data.
     edge_mask:
         Mask for detector edges.
     holder_mask:
         Mask for sample holder.
     """
-    da = da.copy(deep=False)
+    masks = {}
     if edge_mask is not None:
-        da.masks['edges'] = edge_mask
+        masks['edges'] = edge_mask
     if holder_mask is not None:
-        da.masks['holder_mask'] = holder_mask
-    return MaskedData[ScatteringRunType](da)
+        masks['holder_mask'] = holder_mask
+    return DetectorMasks(masks)
 
 
-providers = (detector_edge_mask, sample_holder_mask, mask_detectors)
+providers = (detector_edge_mask, sample_holder_mask, to_detector_masks)
 
 
 def Sans2dWorkflow() -> sciline.Pipeline:

--- a/src/ess/loki/io.py
+++ b/src/ess/loki/io.py
@@ -51,8 +51,7 @@ def load_nexus_detector(
 
 
 def load_nexus_monitor(
-    file_path: Filename[RunType],
-    monitor_name: NeXusMonitorName[MonitorType],
+    file_path: Filename[RunType], monitor_name: NeXusMonitorName[MonitorType]
 ) -> NeXusMonitor[RunType, MonitorType]:
     return NeXusMonitor[RunType, MonitorType](
         nexus.load_monitor(
@@ -71,8 +70,7 @@ def load_detector_event_data(
 
 
 def load_monitor_event_data(
-    file_path: Filename[RunType],
-    monitor_name: NeXusMonitorName[MonitorType],
+    file_path: Filename[RunType], monitor_name: NeXusMonitorName[MonitorType]
 ) -> MonitorEventData[RunType, MonitorType]:
     da = nexus.load_event_data(file_path=file_path, component_name=monitor_name)
     return MonitorEventData[RunType, MonitorType](da)

--- a/src/ess/sans/beam_center_finder.py
+++ b/src/ess/sans/beam_center_finder.py
@@ -12,7 +12,6 @@ from scipp.core import concepts
 
 from .conversions import (
     ElasticCoordTransformGraph,
-    calibrate_positions,
     compute_Q,
     detector_to_wavelength,
     mask_wavelength,
@@ -27,7 +26,6 @@ from .normalization import (
 )
 from .types import (
     BeamCenter,
-    CalibratedMaskedData,
     DetectorPixelShape,
     DimsToKeep,
     IofQ,
@@ -197,7 +195,9 @@ def _iofq_in_quadrants(
 
     pipeline = sciline.Pipeline(providers, params=params)
     pipeline[MaskedData[SampleRun]] = data
-    calibrated = pipeline.compute(CalibratedMaskedData[SampleRun])
+    calibrated = pipeline.compute(MaskedData[SampleRun])
+    assert False
+    # calibrated = pipeline.compute(CalibratedMaskedData[SampleRun])
     with_phi = calibrated.transform_coords(
         'phi', graph=graph, keep_intermediate=False, keep_inputs=False
     )

--- a/src/ess/sans/beam_center_finder.py
+++ b/src/ess/sans/beam_center_finder.py
@@ -117,7 +117,7 @@ def _offsets_to_vector(data: sc.DataArray, xy: list[float], graph: dict) -> sc.V
 
 def _iofq_in_quadrants(
     xy: list[float],
-    pipeline: sciline.Pipeline,
+    workflow: sciline.Pipeline,
     detector: sc.DataArray,
     norm: sc.DataArray,
 ) -> dict[str, sc.DataArray]:
@@ -144,10 +144,10 @@ def _iofq_in_quadrants(
     phi_bins = sc.linspace('phi', -pi, pi, 5, unit='rad')
     quadrants = ['south-west', 'south-east', 'north-east', 'north-west']
 
-    graph = pipeline.compute(ElasticCoordTransformGraph)
-    pipeline = pipeline.copy()
-    pipeline[BeamCenter] = _offsets_to_vector(data=detector, xy=xy, graph=graph)
-    calibrated = pipeline.compute(MaskedData[SampleRun])
+    graph = workflow.compute(ElasticCoordTransformGraph)
+    workflow = workflow.copy()
+    workflow[BeamCenter] = _offsets_to_vector(data=detector, xy=xy, graph=graph)
+    calibrated = workflow.compute(MaskedData[SampleRun])
     with_phi = calibrated.transform_coords(
         'phi', graph=graph, keep_intermediate=False, keep_inputs=False
     )
@@ -165,13 +165,13 @@ def _iofq_in_quadrants(
     for i, quad in enumerate(quadrants):
         # Select pixels based on phi
         sel = (phi >= phi_bins[i]) & (phi < phi_bins[i + 1])
-        pipeline[RawDetector[SampleRun]] = detector[sel]
+        workflow[RawDetector[SampleRun]] = detector[sel]
         # MaskedData would be computed automatically, but we did it above already
-        pipeline[MaskedData[SampleRun]] = calibrated[sel]
-        pipeline[NormWavelengthTerm[SampleRun]] = (
+        workflow[MaskedData[SampleRun]] = calibrated[sel]
+        workflow[NormWavelengthTerm[SampleRun]] = (
             norm if norm.dims == ('wavelength',) else norm[sel]
         )
-        out[quad] = pipeline.compute(IofQ[SampleRun])
+        out[quad] = workflow.compute(IofQ[SampleRun])
     return out
 
 

--- a/src/ess/sans/conversions.py
+++ b/src/ess/sans/conversions.py
@@ -11,8 +11,6 @@ from scippneutron.conversion.graph import beamline, tof
 
 from .common import mask_range
 from .types import (
-    BeamCenter,
-    CalibratedMaskedData,
     CleanQ,
     CleanQxy,
     CleanWavelength,
@@ -153,24 +151,11 @@ def monitor_to_wavelength(
     )
 
 
-def calibrate_positions(
-    detector: MaskedData[ScatteringRunType], beam_center: BeamCenter
-) -> CalibratedMaskedData[ScatteringRunType]:
-    """
-    Calibrate pixel positions.
-
-    Currently the only applied calibration is the beam-center offset.
-    """
-    detector = detector.copy(deep=False)
-    detector.coords['position'] = detector.coords['position'] - beam_center
-    return detector
-
-
 # TODO This demonstrates a problem: Transforming to wavelength should be possible
 # for RawData, MaskedData, ... no reason to restrict necessarily.
 # Would we be fine with just choosing on option, or will this get in the way for users?
 def detector_to_wavelength(
-    detector: CalibratedMaskedData[ScatteringRunType],
+    detector: MaskedData[ScatteringRunType],
     graph: ElasticCoordTransformGraph,
 ) -> CleanWavelength[ScatteringRunType, Numerator]:
     return CleanWavelength[ScatteringRunType, Numerator](
@@ -227,7 +212,6 @@ def compute_Qxy(
 providers = (
     sans_elastic,
     sans_monitor,
-    calibrate_positions,
     monitor_to_wavelength,
     detector_to_wavelength,
     mask_wavelength,

--- a/src/ess/sans/normalization.py
+++ b/src/ess/sans/normalization.py
@@ -5,6 +5,7 @@ from ess.reduce.uncertainty import UncertaintyBroadcastMode, broadcast_uncertain
 from scipp.core import concepts
 
 from .types import (
+    CalibratedDetector,
     CleanDirectBeam,
     CleanMonitor,
     CleanSummedQ,
@@ -22,7 +23,6 @@ from .types import (
     NormWavelengthTerm,
     Numerator,
     ProcessedWavelengthBands,
-    RawDetector,
     ReturnEvents,
     ScatteringRunType,
     SolidAngle,
@@ -35,7 +35,7 @@ from .types import (
 
 
 def solid_angle(
-    data: RawDetector[ScatteringRunType],
+    data: CalibratedDetector[ScatteringRunType],
     pixel_shape: DetectorPixelShape[ScatteringRunType],
     transform: LabFrameTransform[ScatteringRunType],
 ) -> SolidAngle[ScatteringRunType]:

--- a/src/ess/sans/normalization.py
+++ b/src/ess/sans/normalization.py
@@ -5,22 +5,24 @@ from ess.reduce.uncertainty import UncertaintyBroadcastMode, broadcast_uncertain
 from scipp.core import concepts
 
 from .types import (
-    CalibratedMaskedData,
     CleanDirectBeam,
     CleanMonitor,
     CleanSummedQ,
     CleanSummedQxy,
     CleanWavelength,
     Denominator,
+    DetectorMasks,
     DetectorPixelShape,
     EmptyBeamRun,
     Incident,
     IofQ,
     IofQxy,
     LabFrameTransform,
+    MaskedSolidAngle,
     NormWavelengthTerm,
     Numerator,
     ProcessedWavelengthBands,
+    RawDetector,
     ReturnEvents,
     ScatteringRunType,
     SolidAngle,
@@ -33,7 +35,7 @@ from .types import (
 
 
 def solid_angle(
-    data: CalibratedMaskedData[ScatteringRunType],
+    data: RawDetector[ScatteringRunType],
     pixel_shape: DetectorPixelShape[ScatteringRunType],
     transform: LabFrameTransform[ScatteringRunType],
 ) -> SolidAngle[ScatteringRunType]:
@@ -79,6 +81,13 @@ def solid_angle(
             prototype=data, data=omega, dim=set(data.dims) - set(omega.dims)
         )
     )
+
+
+def mask_solid_angle(
+    solid_angle: SolidAngle[ScatteringRunType],
+    masks: DetectorMasks,
+) -> MaskedSolidAngle[ScatteringRunType]:
+    return MaskedSolidAngle[ScatteringRunType](solid_angle.assign_masks(masks))
 
 
 def _approximate_solid_angle_for_cylinder_shaped_pixel_of_detector(
@@ -219,7 +228,7 @@ def iofq_norm_wavelength_term(
 
 def iofq_denominator(
     wavelength_term: NormWavelengthTerm[ScatteringRunType],
-    solid_angle: SolidAngle[ScatteringRunType],
+    solid_angle: MaskedSolidAngle[ScatteringRunType],
     uncertainties: UncertaintyBroadcastMode,
 ) -> CleanWavelength[ScatteringRunType, Denominator]:
     """
@@ -452,4 +461,5 @@ providers = (
     normalize_qxy,
     process_wavelength_bands,
     solid_angle,
+    mask_solid_angle,
 )

--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -217,6 +217,10 @@ class SolidAngle(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
     """Solid angle of detector pixels seen from sample position"""
 
 
+class MaskedSolidAngle(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
+    """Same as :py:class:`SolidAngle`, but with pixel masks applied"""
+
+
 class NeXusDetector(sciline.Scope[RunType, sc.DataGroup], sc.DataGroup):
     """Detector data, loaded from a NeXus file, containing not only neutron events
     but also pixel shape information, transformations, ..."""
@@ -264,12 +268,6 @@ PixelMask = NewType('PixelMask', sc.Variable)
 
 class MaskedData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
     """Raw data with pixel-specific masks applied"""
-
-
-class CalibratedMaskedData(
-    sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray
-):
-    """Raw data with pixel-specific masks applied and calibrated pixel positions"""
 
 
 class NormWavelengthTerm(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):

--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -244,13 +244,15 @@ class MonitorEventData(
 
 
 class RawDetector(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
-    """Raw detector data component extracted from :py:class:`NeXusDetector`"""
+    """Raw detector component extracted from :py:class:`NeXusDetector`"""
 
 
-class RawDetectorData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
-    """Raw event data where variances and necessary coordinates
-    (e.g. sample and source position) have been added, and where optionally some
-    user configuration was applied to some of the coordinates."""
+class CalibratedDetector(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
+    """Calibrated version of raw detector"""
+
+
+class DetectorData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):
+    """Calibrated detector with added raw event data"""
 
 
 class TofData(sciline.Scope[ScatteringRunType, sc.DataArray], sc.DataArray):

--- a/tests/isissans/sans2d_reduction_test.py
+++ b/tests/isissans/sans2d_reduction_test.py
@@ -215,6 +215,15 @@ def test_beam_center_from_center_of_mass_is_close_to_verified_result():
     assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(3e-3, unit='m'))
 
 
+def test_beam_center_from_center_of_mass_independent_of_set_beam_center():
+    params = make_params()
+    providers = sans2d_providers()
+    pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0.1, -0.1, 0], unit='m')
+    center = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
+    assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(3e-3, unit='m'))
+
+
 def test_beam_center_finder_without_direct_beam_reproduces_verified_result():
     params = make_params()
     del params[DirectBeamFilename]
@@ -253,6 +262,20 @@ def test_beam_center_finder_works_with_direct_beam():
     params = make_params()
     providers = sans2d_providers()
     pipeline = sciline.Pipeline(providers, params=params)
+    q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
+    center_with_direct_beam = sans.beam_center_finder.beam_center_from_iofq(
+        workflow=pipeline, q_bins=q_bins
+    )
+    assert sc.allclose(
+        center_with_direct_beam, MANTID_BEAM_CENTER, atol=sc.scalar(2e-3, unit='m')
+    )
+
+
+def test_beam_center_finder_independent_of_set_beam_center():
+    params = make_params()
+    providers = sans2d_providers()
+    pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0.1, -0.1, 0], unit='m')
     q_bins = sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
     center_with_direct_beam = sans.beam_center_finder.beam_center_from_iofq(
         workflow=pipeline, q_bins=q_bins

--- a/tests/isissans/sans2d_reduction_test.py
+++ b/tests/isissans/sans2d_reduction_test.py
@@ -119,7 +119,7 @@ def test_pipeline_can_compute_background_subtracted_IofQ_in_wavelength_bands():
 def test_pipeline_wavelength_bands_is_optional():
     params = make_params()
     pipeline = sciline.Pipeline(sans2d_providers(), params=params)
-    pipeline[BeamCenter] = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
+    pipeline[BeamCenter] = sans.beam_center_from_center_of_mass(pipeline)
     noband = pipeline.compute(BackgroundSubtractedIofQ)
     assert pipeline.compute(WavelengthBands) is None
     band = sc.linspace('wavelength', 2.0, 16.0, num=2, unit='angstrom')
@@ -133,7 +133,7 @@ def test_workflow_is_deterministic():
     params = make_params()
     params[UncertaintyBroadcastMode] = UncertaintyBroadcastMode.drop
     pipeline = sciline.Pipeline(sans2d_providers(), params=params)
-    pipeline[BeamCenter] = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
+    pipeline[BeamCenter] = sans.beam_center_from_center_of_mass(pipeline)
     # This is Sciline's default scheduler, but we want to be explicit here
     scheduler = sciline.scheduler.DaskScheduler()
     graph = pipeline.get(IofQ[SampleRun], scheduler=scheduler)
@@ -208,7 +208,7 @@ def test_beam_center_from_center_of_mass_is_close_to_verified_result():
     params = make_params()
     providers = sans2d_providers()
     pipeline = sciline.Pipeline(providers, params=params)
-    center = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
+    center = sans.beam_center_from_center_of_mass(pipeline)
     # This is the result obtained from Mantid, using the full IofQ
     # calculation. The difference is about 3 mm in X or Y, probably due to a bias
     # introduced by the sample holder, which the center-of-mass approach cannot ignore.
@@ -220,7 +220,7 @@ def test_beam_center_from_center_of_mass_independent_of_set_beam_center():
     providers = sans2d_providers()
     pipeline = sciline.Pipeline(providers, params=params)
     pipeline[BeamCenter] = sc.vector([0.1, -0.1, 0], unit='m')
-    center = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
+    center = sans.beam_center_from_center_of_mass(pipeline)
     assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(3e-3, unit='m'))
 
 

--- a/tests/isissans/sans2d_reduction_test.py
+++ b/tests/isissans/sans2d_reduction_test.py
@@ -228,18 +228,13 @@ def test_beam_center_from_center_of_mass_is_close_to_verified_result():
 
 def test_beam_center_finder_without_direct_beam_reproduces_verified_result():
     params = make_params()
-    params[sans.beam_center_finder.BeamCenterFinderQBins] = sc.linspace(
-        'Q', 0.02, 0.3, 71, unit='1/angstrom'
-    )
     del params[DirectBeamFilename]
     providers = sans2d_providers()
-    providers.remove(sans.beam_center_finder.beam_center_from_center_of_mass)
-    providers.append(sans.beam_center_finder.beam_center_from_iofq)
     pipeline = sciline.Pipeline(providers, params=params)
-    pipeline[sans.beam_center_finder.BeamCenterFinderMinimizer] = None
-    pipeline[sans.beam_center_finder.BeamCenterFinderTolerance] = None
     pipeline[DirectBeam] = None
-    center = pipeline.compute(BeamCenter)
+    center = sans.beam_center_finder.beam_center_from_iofq(
+        workflow=pipeline, q_bins=sc.linspace('Q', 0.02, 0.3, 71, unit='1/angstrom')
+    )
     assert sc.allclose(center, MANTID_BEAM_CENTER, atol=sc.scalar(2e-3, unit='m'))
 
 

--- a/tests/isissans/zoom_reduction_test.py
+++ b/tests/isissans/zoom_reduction_test.py
@@ -5,6 +5,7 @@ import scipp as sc
 from ess import isissans as isis
 from ess import sans
 from ess.sans.types import (
+    BeamCenter,
     CorrectForGravity,
     Filename,
     Incident,
@@ -63,13 +64,13 @@ def zoom_providers():
             isis.data.load_tutorial_run,
             isis.data.transmission_from_background_run,
             isis.data.transmission_from_sample_run,
-            sans.beam_center_finder.beam_center_from_center_of_mass,
         )
     )
 
 
 def test_can_create_pipeline():
     pipeline = sciline.Pipeline(zoom_providers(), params=make_params())
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, isis.data.zoom_tutorial_mask_filenames()
     )
@@ -78,6 +79,7 @@ def test_can_create_pipeline():
 
 def test_pipeline_can_compute_IofQ():
     pipeline = sciline.Pipeline(zoom_providers(), params=make_params())
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, isis.data.zoom_tutorial_mask_filenames()
     )
@@ -87,6 +89,7 @@ def test_pipeline_can_compute_IofQ():
 
 def test_pipeline_can_compute_IofQxQy():
     pipeline = sciline.Pipeline(zoom_providers(), params=make_params())
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, isis.data.zoom_tutorial_mask_filenames()
     )

--- a/tests/loki/common.py
+++ b/tests/loki/common.py
@@ -55,7 +55,7 @@ def make_params(no_masks: bool = True) -> dict:
     return params
 
 
-def loki_providers_no_beam_center_finder() -> list[Callable]:
+def loki_providers() -> list[Callable]:
     from ess.isissans.io import read_xml_detector_masking
 
     return list(
@@ -66,10 +66,3 @@ def loki_providers_no_beam_center_finder() -> list[Callable]:
             loki.io.dummy_load_sample,
         )
     )
-
-
-def loki_providers() -> list[Callable]:
-    return [
-        *loki_providers_no_beam_center_finder(),
-        sans.beam_center_finder.beam_center_from_center_of_mass,
-    ]

--- a/tests/loki/directbeam_test.py
+++ b/tests/loki/directbeam_test.py
@@ -6,7 +6,13 @@ from pathlib import Path
 import sciline
 import scipp as sc
 from ess import loki, sans
-from ess.sans.types import DimsToKeep, QBins, WavelengthBands, WavelengthBins
+from ess.sans.types import (
+    BeamCenter,
+    DimsToKeep,
+    QBins,
+    WavelengthBands,
+    WavelengthBins,
+)
 from scipp.scipy.interpolate import interp1d
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -30,6 +36,7 @@ def test_can_compute_direct_beam_for_all_pixels():
     )
     providers = loki_providers()
     pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     I0 = _get_I0(qbins=params[QBins])
 
     results = sans.direct_beam(workflow=pipeline, I0=I0, niter=4)
@@ -59,6 +66,7 @@ def test_can_compute_direct_beam_with_overlapping_wavelength_bands():
 
     providers = loki_providers()
     pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     I0 = _get_I0(qbins=params[QBins])
 
     results = sans.direct_beam(workflow=pipeline, I0=I0, niter=4)
@@ -84,6 +92,7 @@ def test_can_compute_direct_beam_per_layer():
     params[DimsToKeep] = ['layer']
     providers = loki_providers()
     pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     I0 = _get_I0(qbins=params[QBins])
 
     results = sans.direct_beam(workflow=pipeline, I0=I0, niter=4)
@@ -111,6 +120,7 @@ def test_can_compute_direct_beam_per_layer_and_straw():
     params[DimsToKeep] = ('layer', 'straw')
     providers = loki_providers()
     pipeline = sciline.Pipeline(providers, params=params)
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     I0 = _get_I0(qbins=params[QBins])
 
     results = sans.direct_beam(workflow=pipeline, I0=I0, niter=4)

--- a/tests/loki/iofq_test.py
+++ b/tests/loki/iofq_test.py
@@ -13,7 +13,6 @@ from ess.sans.types import (
     BackgroundSubtractedIofQ,
     BackgroundSubtractedIofQxy,
     BeamCenter,
-    CalibratedMaskedData,
     CleanSummedQ,
     CleanWavelengthMasked,
     CorrectForGravity,
@@ -21,6 +20,7 @@ from ess.sans.types import (
     DimsToKeep,
     IofQ,
     IofQxy,
+    MaskedData,
     NeXusDetectorName,
     Numerator,
     QBins,
@@ -37,13 +37,13 @@ from scipp.testing import assert_identical
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from common import (
     loki_providers,
-    loki_providers_no_beam_center_finder,
     make_params,
 )
 
 
 def test_can_create_pipeline():
     pipeline = sciline.Pipeline(loki_providers(), params=make_params())
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     pipeline.get(BackgroundSubtractedIofQ)
 
 
@@ -52,6 +52,7 @@ def test_can_create_pipeline_with_pixel_masks():
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, loki.data.loki_tutorial_mask_filenames()
     )
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
     pipeline.get(BackgroundSubtractedIofQ)
 
 
@@ -67,6 +68,8 @@ def test_pipeline_can_compute_IofQ(uncertainties, qxy: bool):
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, loki.data.loki_tutorial_mask_filenames()
     )
+    pipeline[BeamCenter] = sc.vector([0.0, 0.0, 0.0], unit='m')
+    pipeline[BeamCenter] = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
     if qxy:
         result = pipeline.compute(BackgroundSubtractedIofQxy)
         assert result.dims == ('Qy', 'Qx')
@@ -103,6 +106,8 @@ def test_pipeline_can_compute_IofQ_in_event_mode(uncertainties, target):
     params = make_params()
     params[UncertaintyBroadcastMode] = uncertainties
     pipeline = sciline.Pipeline(loki_providers(), params=params)
+    pipeline[BeamCenter] = sc.vector([0.0, 0.0, 0.0], unit='m')
+    pipeline[BeamCenter] = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
     reference = pipeline.compute(target)
     pipeline[ReturnEvents] = True
     result = pipeline.compute(target)
@@ -141,6 +146,7 @@ def test_pipeline_can_compute_IofQ_in_wavelength_bands(qxy: bool):
         11,
     )
     pipeline = sciline.Pipeline(loki_providers(), params=params)
+    pipeline[BeamCenter] = _compute_beam_center()
     result = pipeline.compute(
         BackgroundSubtractedIofQxy if qxy else BackgroundSubtractedIofQ
     )
@@ -159,6 +165,7 @@ def test_pipeline_can_compute_IofQ_in_overlapping_wavelength_bands(qxy: bool):
         [edges[:-2], edges[2::]], dim='wavelength'
     ).transpose()
     pipeline = sciline.Pipeline(loki_providers(), params=params)
+    pipeline[BeamCenter] = _compute_beam_center()
     result = pipeline.compute(
         BackgroundSubtractedIofQxy if qxy else BackgroundSubtractedIofQ
     )
@@ -171,6 +178,7 @@ def test_pipeline_can_compute_IofQ_in_layers(qxy: bool):
     params = make_params()
     params[DimsToKeep] = ['layer']
     pipeline = sciline.Pipeline(loki_providers(), params=params)
+    pipeline[BeamCenter] = _compute_beam_center()
     result = pipeline.compute(
         BackgroundSubtractedIofQxy if qxy else BackgroundSubtractedIofQ
     )
@@ -180,8 +188,8 @@ def test_pipeline_can_compute_IofQ_in_layers(qxy: bool):
 
 def _compute_beam_center():
     pipeline = sciline.Pipeline(loki_providers(), params=make_params())
-    center = pipeline.compute(BeamCenter)
-    return center
+    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
+    return pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
 
 
 def test_pipeline_can_compute_IofQ_merging_events_from_multiple_runs():
@@ -195,7 +203,7 @@ def test_pipeline_can_compute_IofQ_merging_events_from_multiple_runs():
         loki.data.loki_tutorial_background_run_60248(),
         loki.data.loki_tutorial_background_run_60393(),
     ]
-    pipeline = sciline.Pipeline(loki_providers_no_beam_center_finder(), params=params)
+    pipeline = sciline.Pipeline(loki_providers(), params=params)
     pipeline[BeamCenter] = _compute_beam_center()
 
     pipeline = sans.with_sample_runs(pipeline, runs=sample_runs)
@@ -209,7 +217,7 @@ def test_pipeline_can_compute_IofQ_by_bank():
     params = make_params()
     del params[NeXusDetectorName]
 
-    pipeline = sciline.Pipeline(loki_providers_no_beam_center_finder(), params=params)
+    pipeline = sciline.Pipeline(loki_providers(), params=params)
     pipeline[BeamCenter] = _compute_beam_center()
     pipeline = sans.with_banks(pipeline, banks=['larmor_detector'])
 
@@ -227,7 +235,7 @@ def test_pipeline_can_compute_IofQ_merging_events_from_multiple_runs_by_bank():
         loki.data.loki_tutorial_background_run_60248(),
         loki.data.loki_tutorial_background_run_60393(),
     ]
-    pipeline = sciline.Pipeline(loki_providers_no_beam_center_finder(), params=params)
+    pipeline = sciline.Pipeline(loki_providers(), params=params)
     pipeline[BeamCenter] = _compute_beam_center()
 
     pipeline = sans.with_sample_runs(pipeline, runs=sample_runs)
@@ -248,9 +256,7 @@ def test_pipeline_IofQ_merging_events_yields_consistent_results():
     N = 3
     params = make_params()
     center = _compute_beam_center()
-    pipeline_single = sciline.Pipeline(
-        loki_providers_no_beam_center_finder(), params=params
-    )
+    pipeline_single = sciline.Pipeline(loki_providers(), params=params)
     pipeline_single[BeamCenter] = center
 
     sample_runs = [loki.data.loki_tutorial_sample_run_60339()] * N
@@ -285,7 +291,8 @@ def test_beam_center_from_center_of_mass_is_close_to_verified_result():
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, loki.data.loki_tutorial_mask_filenames()
     )
-    center = pipeline.compute(BeamCenter)
+    pipeline[BeamCenter] = sc.vector([0.0, 0.0, 0.0], unit='m')
+    center = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
     reference = sc.vector([-0.0291487, -0.0181614, 0], unit='m')
     assert sc.allclose(center, reference)
 
@@ -293,6 +300,7 @@ def test_beam_center_from_center_of_mass_is_close_to_verified_result():
 def test_phi_with_gravity():
     params = make_params()
     pipeline = sciline.Pipeline(loki_providers(), params=params)
+    pipeline[BeamCenter] = _compute_beam_center()
     pipeline[CorrectForGravity] = False
     data_no_grav = pipeline.compute(
         CleanWavelengthMasked[SampleRun, Numerator]
@@ -316,7 +324,7 @@ def test_phi_with_gravity():
     # Exclude pixels near y=0, since phi with gravity could drop below y=0 and give a
     # difference of almost 2*pi.
     y = sc.abs(
-        pipeline.compute(CalibratedMaskedData[SampleRun])
+        pipeline.compute(MaskedData[SampleRun])
         .coords['position']
         .fields.y.flatten(to='pixel')
     )

--- a/tests/loki/iofq_test.py
+++ b/tests/loki/iofq_test.py
@@ -68,8 +68,7 @@ def test_pipeline_can_compute_IofQ(uncertainties, qxy: bool):
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, loki.data.loki_tutorial_mask_filenames()
     )
-    pipeline[BeamCenter] = sc.vector([0.0, 0.0, 0.0], unit='m')
-    pipeline[BeamCenter] = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
+    pipeline[BeamCenter] = sans.beam_center_from_center_of_mass(pipeline)
     if qxy:
         result = pipeline.compute(BackgroundSubtractedIofQxy)
         assert result.dims == ('Qy', 'Qx')
@@ -106,8 +105,7 @@ def test_pipeline_can_compute_IofQ_in_event_mode(uncertainties, target):
     params = make_params()
     params[UncertaintyBroadcastMode] = uncertainties
     pipeline = sciline.Pipeline(loki_providers(), params=params)
-    pipeline[BeamCenter] = sc.vector([0.0, 0.0, 0.0], unit='m')
-    pipeline[BeamCenter] = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
+    pipeline[BeamCenter] = sans.beam_center_from_center_of_mass(pipeline)
     reference = pipeline.compute(target)
     pipeline[ReturnEvents] = True
     result = pipeline.compute(target)
@@ -188,8 +186,7 @@ def test_pipeline_can_compute_IofQ_in_layers(qxy: bool):
 
 def _compute_beam_center():
     pipeline = sciline.Pipeline(loki_providers(), params=make_params())
-    pipeline[BeamCenter] = sc.vector([0, 0, 0], unit='m')
-    return pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
+    return sans.beam_center_from_center_of_mass(pipeline)
 
 
 def test_pipeline_can_compute_IofQ_merging_events_from_multiple_runs():
@@ -291,8 +288,7 @@ def test_beam_center_from_center_of_mass_is_close_to_verified_result():
     pipeline = sans.with_pixel_mask_filenames(
         pipeline, loki.data.loki_tutorial_mask_filenames()
     )
-    pipeline[BeamCenter] = sc.vector([0.0, 0.0, 0.0], unit='m')
-    center = pipeline.bind_and_call(sans.beam_center_from_center_of_mass)
+    center = sans.beam_center_from_center_of_mass(pipeline)
     reference = sc.vector([-0.0291487, -0.0181614, 0], unit='m')
     assert sc.allclose(center, reference)
 


### PR DESCRIPTION
Fixes #154.

There are some subtleties here, around different way of handling ESS NeXus vs. Mantid files.

The I(Q) beam-center finder was a headache, but I hope by passing the workflow I managed to make it a bit more natural. There is potential room for improvement, by avoiding reloading data even if positions change, but I left it for now until we know if this actually is an issue in practice.