### PR TITLE
Do not set filename twice

### DIFF
--- a/src/ess/loki/general.py
+++ b/src/ess/loki/general.py
@@ -125,9 +125,6 @@ def LokiAtLarmorTutorialWorkflow() -> sciline.Pipeline:
     from ess.loki import data
 
     workflow = LokiAtLarmorWorkflow()
-    workflow[sans.types.Filename[sans.types.SampleRun]] = (
-        data.loki_tutorial_sample_run_60339()
-    )
     # TODO This does not work with multiple
     workflow[sans.types.PixelMaskFilename] = data.loki_tutorial_mask_filenames()[0]
 


### PR DESCRIPTION
Noticed the `Filename[SampleRun]` parameter is being set twice in the tutorial workflow.

See https://github.com/scipp/esssans/pull/180/files#diff-1001856c8c18f9091de94b1665f73aad52419e6df21c119f411993d60dbe83c7L134-L136