### PR TITLE
Add Q-resolution support

### DIFF
--- a/src/ess/sans/common.py
+++ b/src/ess/sans/common.py
@@ -61,7 +61,7 @@ def mask_range(
 
     coord = (
         da.bins.constituents['data'].coords[dim]
-        if da.bins is not None
+        if da.bins is not None and dim in da.bins.coords
         else da.coords[dim]
     )
     edges = edges.to(unit=coord.unit)

--- a/src/ess/sans/common.py
+++ b/src/ess/sans/common.py
@@ -66,7 +66,7 @@ def mask_range(
     )
     edges = edges.to(unit=coord.unit)
     lu = sc.DataArray(data=mask.data, coords={dim: edges})
-    if da.bins is not None:
+    if da.bins is not None and dim in da.bins.coords:
         if dim not in da.coords:
             underlying = da.bins.coords[dim]
             new_bins = np.union1d(

--- a/src/ess/sans/conversions.py
+++ b/src/ess/sans/conversions.py
@@ -3,7 +3,6 @@
 from typing import NewType
 
 import scipp as sc
-from scipp.constants import pi
 from scippneutron.conversion.beamline import (
     beam_aligned_unit_vectors,
     scattering_angles_with_gravity,
@@ -26,7 +25,6 @@ from .types import (
     MonitorTerm,
     MonitorType,
     Numerator,
-    Resolution,
     RunType,
     ScatteringRunType,
     TofMonitor,
@@ -173,38 +171,12 @@ def detector_to_wavelength(
     )
 
 
-ModeratorTimeSpread = NewType("ModeratorTimeSpread", sc.DataArray)
-"""Moderator time-spread as a function of wavelength."""
-
-
 def mask_wavelength_q(
     da: CleanSummedQ[ScatteringRunType, Numerator], mask: WavelengthMask
 ) -> WavelengthScaledQ[ScatteringRunType, Numerator]:
     if mask is not None:
         da = mask_range(da, mask=mask)
     return WavelengthScaledQ[ScatteringRunType, Numerator](da)
-
-
-def mask_and_compute_resolution_q(
-    pixel_term: CleanSummedQ[ScatteringRunType, Resolution],
-    mask: WavelengthMask,
-    moderator_time_spread: ModeratorTimeSpread,
-) -> WavelengthScaledQ[ScatteringRunType, Resolution]:
-    """
-    Compute the masked Q-resolution in (Q, lambda) space.
-
-    CleanSummedQ has been summed over pixels but not over wavelengths. This is exactly
-    what is required for performing the remaining scaling and addition of the moderator
-    term to obtain the Q-resolution. The result is still in (Q, lambda) space.
-    """
-    if mask is not None:
-        pixel_term = mask_range(pixel_term, mask=mask)
-    lambda2 = pixel_term.coords['wavelength'] ** 2
-    Q2 = pixel_term.coords['Q'] ** 2
-    resolution = (
-        pi**2 / (3 * lambda2**2) * pixel_term + Q2 * moderator_time_spread**2 / lambda2
-    )
-    return WavelengthScaledQ[ScatteringRunType, Resolution](resolution)
 
 
 def mask_wavelength_qxy(
@@ -284,7 +256,6 @@ providers = (
     detector_to_wavelength,
     mask_wavelength_q,
     mask_wavelength_qxy,
-    mask_and_compute_resolution_q,
     mask_and_scale_wavelength_q,
     mask_and_scale_wavelength_qxy,
     compute_Q,

--- a/src/ess/sans/normalization.py
+++ b/src/ess/sans/normalization.py
@@ -392,7 +392,7 @@ def _reduce(part: sc.DataArray, /, *, bands: ProcessedWavelengthBands) -> sc.Dat
         Q-dependent data, ready for normalization.
     """
     wav = 'wavelength'
-    if part.bins is not None:
+    if part.bins is not None and wav in part.bins.coords:
         # If in event mode the desired wavelength binning has not been applied, we need
         # it for splitting by bands, or restricting the range in case of a single band.
         part = part.bin(wavelength=sc.sort(bands.flatten(to=wav), wav))

--- a/src/ess/sans/qresolution.py
+++ b/src/ess/sans/qresolution.py
@@ -174,8 +174,12 @@ def q_resolution_by_pixel(
         3 * ((source_aperture / collimation_length) ** 2 + (sample_aperture / L3) ** 2)
         + (delta_r / L2) ** 2
     )
-    sigma_lambda2 = result.data**2 + delta_lambda**2 / 12
-    result.data = (pi**2 / 3) * pixel_term + result.coords['Q'] ** 2 * sigma_lambda2
+    # Written in multiple steps to avoid allocation of intermediate arrays. This is
+    # makes this step about twice as fast (but computing Q above dominates anyway).
+    result.data *= result.data
+    result.data += delta_lambda**2 / 12
+    result.data *= result.coords['Q'] ** 2
+    result.data += (pi**2 / 3) * pixel_term
     inv_lambda = sc.reciprocal(result.coords['wavelength'])
     return QResolutionByPixel(sc.sqrt(result) * inv_lambda)
 

--- a/src/ess/sans/qresolution.py
+++ b/src/ess/sans/qresolution.py
@@ -144,6 +144,12 @@ def q_resolution_by_pixel(
     """
     Calculate the Q-resolution per pixel and wavelength.
 
+    This is a Gaussian approximation to the Q-resolution (Mildner and Carpenter). It is
+    likely not sufficient for the long ESS pulse. Based on communication with Andrew
+    Jackson this "approximation works OK when you have all your Q points from a single
+    planar detector (as on SANS2D) and was implemented by Richard Heenan as a 'hack' to
+    get a resolution value of some kind".
+
     Parameters
     ----------
     sigma_moderator:
@@ -181,8 +187,9 @@ def q_resolution_by_pixel(
     result.data += delta_lambda**2 / 12
     result.data *= result.coords['Q'] ** 2
     result.data += (pi**2 / 3) * pixel_term
-    inv_lambda = sc.reciprocal(result.coords['wavelength'])
-    return QResolutionByPixel(sc.sqrt(result) * inv_lambda)
+    result = sc.sqrt(result)
+    result /= result.coords['wavelength']
+    return QResolutionByPixel(result)
 
 
 def q_resolution_by_wavelength(

--- a/src/ess/sans/qresolution.py
+++ b/src/ess/sans/qresolution.py
@@ -4,19 +4,23 @@
 
 from typing import NewType
 
+import numpy as np
 import scipp as sc
 from scipp.constants import pi
 
 from .common import mask_range
 from .conversions import ElasticCoordTransformGraph
+from .i_of_q import resample_direct_beam
 from .normalization import _reduce
 from .types import (
+    CalibratedBeamline,
     CleanQ,
     Denominator,
     DimsToKeep,
     ProcessedWavelengthBands,
     QBins,
     SampleRun,
+    WavelengthBins,
     WavelengthMask,
 )
 
@@ -28,17 +32,78 @@ SampleApertureRadius = NewType("SampleApertureRadius", sc.Variable)
 SourceApertureRadius = NewType("SourceApertureRadius", sc.Variable)
 """Source aperture radius, R1."""
 SigmaModerator = NewType("SigmaModerator", sc.DataArray)
-"""Moderator time spread as a function of wavelength."""
+"""
+Moderator wavelength spread as a function of wavelength.
+
+This is derived from ModeratorTimeSpread.
+"""
 CollimationLength = NewType("CollimationLength", sc.Variable)
 """Collimation length."""
+ModeratorTimeSpreadFilename = NewType("ModeratorTimeSpreadFilename", str)
 ModeratorTimeSpread = NewType("ModeratorTimeSpread", sc.DataArray)
 """Moderator time-spread as a function of wavelength."""
 
 
 QResolutionByPixel = NewType("QResolutionByPixel", sc.DataArray)
-QResolutionByQ = NewType("QResolutionPixelTermGroupedQ", sc.DataArray)
 QResolutionByWavelength = NewType("QResolutionByWavelength", sc.DataArray)
 QResolution = NewType("QResolution", sc.DataArray)
+
+
+def load_isis_moderator_time_spread(
+    filename: ModeratorTimeSpreadFilename,
+) -> ModeratorTimeSpread:
+    """
+    Load moderator time spread from an ISIS moderator file.
+
+    Files looks as follows:
+
+    .. code-block:: text
+
+         Fri 08-Aug-2015, LET exptl data (FWHM/2.35) [...]
+
+          61    0    0    0    1   61    0
+                0         0         0         0
+        3 (F12.5,2E14.6)
+            0.00000  2.257600E+01  0.000000E+00
+            0.50000  2.677152E+01  0.000000E+00
+            1.00000  3.093920E+01  0.000000E+00
+            1.50000  3.507903E+01  0.000000E+00
+            2.00000  3.919100E+01  0.000000E+00
+
+    The first column is the wavelength in Angstrom, the second is the time spread in
+    microseconds. The third column is the error on the time spread, which we ignore.
+    """
+    wavelength, time_spread = np.loadtxt(
+        filename, skiprows=5, usecols=(0, 1), unpack=True
+    )
+    wav = 'wavelength'
+    return ModeratorTimeSpread(
+        sc.DataArray(
+            data=sc.array(dims=[wav], values=time_spread, unit='us'),
+            coords={wav: sc.array(dims=[wav], values=wavelength, unit='angstrom')},
+        )
+    )
+
+
+def moderator_time_spread_to_wavelength_spread(
+    moderator_time_spread: ModeratorTimeSpread,
+    beamline: CalibratedBeamline[SampleRun],
+    graph: ElasticCoordTransformGraph,
+    wavelength_bins: WavelengthBins,
+) -> SigmaModerator:
+    """
+    Convert the moderator time spread to a wavelength spread.
+    """
+    dtof = resample_direct_beam(moderator_time_spread, wavelength_bins=wavelength_bins)
+    # We would like to "transform" the *data*, but we only have transform_coords, so
+    # there is some back and forth between data and coords here.
+    dummy = beamline.broadcast(sizes={**beamline.sizes, **dtof.sizes})
+    dummy.data = sc.empty(sizes=dummy.sizes)
+    da = dummy.assign_coords(tof=dtof.data).transform_coords(
+        'wavelength', graph=graph, keep_inputs=False
+    )
+    da.data = da.coords.pop('wavelength')
+    return SigmaModerator(da.assign_coords(wavelength=wavelength_bins))
 
 
 def q_resolution_by_pixel(
@@ -47,8 +112,9 @@ def q_resolution_by_pixel(
     sample_aperture: SampleApertureRadius,
     source_aperture: SourceApertureRadius,
     collimation_length: CollimationLength,
-    moderator_time_spread: ModeratorTimeSpread,
+    sigma_moderator: SigmaModerator,
     graph: ElasticCoordTransformGraph,
+    wavelength_bins: WavelengthBins,
 ) -> QResolutionByPixel:
     """
     Calculate the Q-resolution per pixel.
@@ -60,7 +126,7 @@ def q_resolution_by_pixel(
     3. We do not depend on neutron data, by using the denominator instead of the
        numerator.
     """
-    detector = detector.transform_coords("L2", graph=graph, keep_inputs=False)
+    detector = detector.transform_coords(('L1', 'L2'), graph=graph, keep_inputs=False)
     L2 = detector.coords["L2"]
     L3 = sc.reciprocal(sc.reciprocal(collimation_length) + sc.reciprocal(L2))
     result = detector.copy(deep=False)
@@ -70,21 +136,18 @@ def q_resolution_by_pixel(
     )
     inv_lambda2 = sc.reciprocal(detector.coords['wavelength'] ** 2)
     Q2 = detector.coords['Q'] ** 2
-    result.data = (pi**2 / 3) * inv_lambda2 * pixel_term + Q2 * (
-        moderator_time_spread**2 * inv_lambda2
-    )
-    return QResolutionByPixel(result)
+    result.data = (pi**2 / 3) * inv_lambda2 * pixel_term
+    delta_lambda = wavelength_bins[1:] - wavelength_bins[:-1]
+    sigma_lambda2 = delta_lambda**2 / 12 + sigma_moderator**2
+    result += Q2 * (sigma_lambda2 * inv_lambda2)
+    return QResolutionByPixel(sc.sqrt(result))
 
 
-def q_resolution_by_q(
-    data: QResolutionByPixel, q_bins: QBins, dims_to_keep: DimsToKeep
-) -> QResolutionByQ:
-    dims = [dim for dim in data.dims if dim not in (*dims_to_keep, 'wavelength')]
-    return QResolutionByQ(data.bin(Q=q_bins, dim=dims))
-
-
-def mask_qresolution_in_wavelength(
-    resolution: QResolutionByQ, mask: WavelengthMask
+def q_resolution_by_wavelength(
+    data: QResolutionByPixel,
+    q_bins: QBins,
+    dims_to_keep: DimsToKeep,
+    mask: WavelengthMask,
 ) -> QResolutionByWavelength:
     """
     Compute the masked Q-resolution in (Q, lambda) space.
@@ -93,6 +156,8 @@ def mask_qresolution_in_wavelength(
     what is required for performing the remaining scaling and addition of the moderator
     term to obtain the Q-resolution. The result is still in (Q, lambda) space.
     """
+    dims = [dim for dim in data.dims if dim not in (*dims_to_keep, 'wavelength')]
+    resolution = data.bin(Q=q_bins, dim=dims)
     if mask is not None:
         resolution = mask_range(resolution, mask=mask)
     return QResolutionByWavelength(resolution)
@@ -105,8 +170,9 @@ def reduce_resolution_q(
 
 
 providers = (
+    load_isis_moderator_time_spread,
+    moderator_time_spread_to_wavelength_spread,
     q_resolution_by_pixel,
-    q_resolution_by_q,
-    mask_qresolution_in_wavelength,
+    q_resolution_by_wavelength,
     reduce_resolution_q,
 )

--- a/src/ess/sans/qresolution.py
+++ b/src/ess/sans/qresolution.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+"""Q-resolution calculation for SANS data."""
+
+from typing import NewType
+
+import scipp as sc
+
+from .types import CleanQ, Denominator, Resolution, SampleRun
+
+DeltaR = NewType("DeltaR", sc.Variable)
+"""Virtual ring width on the detector."""
+
+SampleApertureRadius = NewType("SampleApertureRadius", sc.Variable)
+"""Sample aperture radius, R2."""
+SourceApertureRadius = NewType("SourceApertureRadius", sc.Variable)
+"""Source aperture radius, R1."""
+SigmaModerator = NewType("SigmaModerator", sc.DataArray)
+"""Moderator time spread as a function of wavelength."""
+CollimationLength = NewType("CollimationLength", sc.Variable)
+"""Collimation length."""
+
+ModeratorTimeSpread = NewType("ModeratorTimeSpread", sc.DataArray)
+"""Moderator time-spread as a function of wavelength."""
+
+QResolutionDetectorTerm = NewType("QResolutionDetectorTerm", sc.DataArray)
+
+
+def pixel_term(
+    detector: CleanQ[SampleRun, Denominator],
+    delta_r: DeltaR,
+    sample_aperture: SampleApertureRadius,
+    source_aperture: SourceApertureRadius,
+    collimation_length: CollimationLength,
+) -> CleanQ[SampleRun, Resolution]:
+    """
+    Calculate the pixel term for Q-resolution.
+
+    We compute this based on CleanQ[SampleRun, Denominator]. This ensures that
+
+    1. We get the correct Q-value, based on wavelength binning used elsewhere.
+    2. Masks are included.
+    3. We do not depend on neutron data, by using the denominator instead of the
+       numerator.
+    """
+    L2 = detector.coords["L2"]
+    L3 = sc.reciprocal(sc.reciprocal(collimation_length) + sc.reciprocal(L2))
+    #
+    result = detector.copy(deep=False)
+    result.data = (
+        3 * ((source_aperture / collimation_length) ** 2 + (sample_aperture / L3) ** 2)
+        + (delta_r / L2) ** 2
+    )
+    return CleanQ[SampleRun, Resolution](result)

--- a/src/ess/sans/qresolution.py
+++ b/src/ess/sans/qresolution.py
@@ -8,14 +8,15 @@ import scipp as sc
 from scipp.constants import pi
 
 from .common import mask_range
+from .normalization import _reduce
 from .types import (
     CleanQ,
     Denominator,
     DimsToKeep,
+    ProcessedWavelengthBands,
     QBins,
     SampleRun,
     WavelengthMask,
-    WavelengthScaledQ,
 )
 
 DeltaR = NewType("DeltaR", sc.Variable)
@@ -75,6 +76,8 @@ def groupby_q_max(
     q_bins: QBins,
     dims_to_keep: DimsToKeep,
 ) -> QResolutionPixelTermGroupedQ:
+    # TODO Handle multi dim and dims_to_keep!
+    # Can we use common helper function from bin_in_q?
     out = data.groupby('Q', bins=q_bins).max('detector_number')
     return QResolutionPixelTermGroupedQ(out)
 
@@ -102,14 +105,10 @@ def mask_and_compute_resolution_q(
 
 
 def reduce_resolution_q(
-    data: QResolutionByWavelength,
-    bands: ProcessedWavelengthBands,
+    data: QResolutionByWavelength, bands: ProcessedWavelengthBands
 ) -> QResolution:
-    # TODO
-    # We do not want to use reduce_q, but use a max again!
-    # but reduce_q is quite complex, can we reuse it but use binned data
-    # so it does not sum? or call the underlying helper function!
-    pass
+    # TODO Add op argument to allow injection of different reduction functions
+    return QResolution(_reduce(data, bands, op=sc.max))
 
 
 providers = (

--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -16,6 +16,7 @@ from ess.reduce.nexus import types as reduce_t
 from ess.reduce.uncertainty import UncertaintyBroadcastMode as _UncertaintyBroadcastMode
 
 BackgroundRun = reduce_t.BackgroundRun
+CalibratedBeamline = reduce_t.CalibratedBeamline
 CalibratedDetector = reduce_t.CalibratedDetector
 CalibratedMonitor = reduce_t.CalibratedMonitor
 DetectorData = reduce_t.DetectorData

--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -44,9 +44,7 @@ Numerator = NewType('Numerator', int)
 """Numerator of IofQ"""
 Denominator = NewType('Denominator', int)
 """Denominator of IofQ"""
-Resolution = NewType('Resolution', int)
-"""Q-Resolution"""
-IofQPart = TypeVar('IofQPart', Numerator, Denominator, Resolution)
+IofQPart = TypeVar('IofQPart', Numerator, Denominator)
 """TypeVar used for specifying Numerator or Denominator of IofQ"""
 
 # 1.4  Entry paths in NeXus files

--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -40,11 +40,13 @@ NeXusDetectorName = reduce_t.NeXusDetectorName
 UncertaintyBroadcastMode = _UncertaintyBroadcastMode
 
 # 1.3  Numerator and denominator of IofQ
-Numerator = NewType('Numerator', sc.DataArray)
+Numerator = NewType('Numerator', int)
 """Numerator of IofQ"""
-Denominator = NewType('Denominator', sc.DataArray)
+Denominator = NewType('Denominator', int)
 """Denominator of IofQ"""
-IofQPart = TypeVar('IofQPart', Numerator, Denominator)
+Resolution = NewType('Resolution', int)
+"""Q-Resolution"""
+IofQPart = TypeVar('IofQPart', Numerator, Denominator, Resolution)
 """TypeVar used for specifying Numerator or Denominator of IofQ"""
 
 # 1.4  Entry paths in NeXus files

--- a/src/ess/sans/workflow.py
+++ b/src/ess/sans/workflow.py
@@ -9,7 +9,7 @@ import scipp as sc
 from ess.reduce.nexus.workflow import GenericNeXusWorkflow
 from ess.reduce.parameter import parameter_mappers
 
-from . import common, conversions, i_of_q, masking, normalization
+from . import common, conversions, i_of_q, masking, normalization, qresolution
 from .types import (
     BackgroundRun,
     CleanSummedQ,
@@ -151,6 +151,7 @@ providers = (
     *masking.providers,
     *normalization.providers,
     common.beam_center_to_detector_position_offset,
+    qresolution.pixel_term,
 )
 """
 List of providers for setting up a Sciline pipeline.

--- a/src/ess/sans/workflow.py
+++ b/src/ess/sans/workflow.py
@@ -151,7 +151,7 @@ providers = (
     *masking.providers,
     *normalization.providers,
     common.beam_center_to_detector_position_offset,
-    qresolution.pixel_term,
+    *qresolution.providers,
 )
 """
 List of providers for setting up a Sciline pipeline.


### PR DESCRIPTION
**This is not ready for full review / merging, just gathering Scientist feedback**

Fixes scipp/ess#360.

To try this out use, e.g., `sans2d.ipynb` and add:

```python
workflow[sans.qresolution.SourceApertureRadius] = sc.scalar(0.020, unit='m')
workflow[sans.qresolution.SampleApertureRadius] = sc.scalar(0.008, unit='m')
workflow[sans.qresolution.CollimationLength] = sc.scalar(4.0, unit='m')
workflow[sans.qresolution.DeltaR] = sc.scalar(0.008, unit='m')
workflow[sans.qresolution.ModeratorTimeSpreadFilename] = ('ModeratorStdDev_TS2_SANS_LETexptl_07Aug2015.txt')
resolution = workflow.compute(sans.qresolution.QResolution)
```

Then play with `resolution.bins.mean()` or `resolution.bins.max()`. Note that if `WavelengthBands` is configured, the resolution is computed for each band, as one would expect.

Questions to science reviewer:
1. Is the math correct? I have used https://docs.mantidproject.org/nightly/algorithms/TOFSANSResolutionByPixel-v1 and the linked Mantid code as a reference. Note that the docs there claim some small-angle approximation was made. I guess that is quite wrong for the Loki window-frame banks? What should we do about this?
2. What do you require as final output? Right now I am returning binned data (see docstring), which may be useful for analysis, but I presume ultimately you need something else?