### PR TITLE
Cache paths returned from Pooch to avoid repeated checksum in unit tests

### DIFF
--- a/src/ess/sans/data.py
+++ b/src/ess/sans/data.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2023 Scipp contributors (https://github.com/scipp)
+from functools import cache
 
 
 class Registry:
@@ -18,6 +19,7 @@ class Registry:
     def __contains__(self, key):
         return key in self._registry.registry
 
+    @cache  # noqa: B019
     def get_path(self, name: str, unzip: bool = False) -> str:
         """
         Get the path to a file in the registry.


### PR DESCRIPTION
This seems to save, e.g., 0.3 seconds a whole bunch of times. Not huge but noticeable. Is it a good idea?