### PR TITLE
Do not use ess.reduce's ScatteringRunType

### DIFF
--- a/src/ess/sans/types.py
+++ b/src/ess/sans/types.py
@@ -28,7 +28,6 @@ MonitorPositionOffset = reduce_t.MonitorPositionOffset
 NeXusMonitorName = reduce_t.NeXusName
 NeXusComponent = reduce_t.NeXusComponent
 SampleRun = reduce_t.SampleRun
-ScatteringRunType = reduce_t.ScatteringRunType
 Transmission = reduce_t.TransmissionMonitor
 TransmissionRun = reduce_t.TransmissionRun
 
@@ -44,6 +43,8 @@ RunType = TypeVar(
     TransmissionRun[SampleRun],
     TransmissionRun[BackgroundRun],
 )
+ScatteringRunType = TypeVar('ScatteringRunType', BackgroundRun, SampleRun)
+
 
 UncertaintyBroadcastMode = _UncertaintyBroadcastMode
 


### PR DESCRIPTION
This avoid stray types such as VanadiumRun appearing in workflows. This "bug" happened because initially ScatteringRunType only included runs relevant for SANS, which was a bad assumption. There was no harm from this, except for unused nodes in graphs.