### PR TITLE
docs: replace sample holder by beam stop

### DIFF
--- a/docs/user-guide/common/beam-center-finder.ipynb
+++ b/docs/user-guide/common/beam-center-finder.ipynb
@@ -189,7 +189,7 @@
    "metadata": {},
    "source": [
     "We can now update our previous figure with the new position of the beam center (pink dot),\n",
-    "which is clearly in the center of the beam stop."
+    "which is clearly in the center of the beam/beam stop."
    ]
   },
   {

--- a/docs/user-guide/common/beam-center-finder.ipynb
+++ b/docs/user-guide/common/beam-center-finder.ipynb
@@ -67,7 +67,7 @@
     "### Masking bad pixels\n",
     "\n",
     "We create a quick image of the data (summing along the `tof` dimension) to inspect its contents.\n",
-    "We see a diffuse scattering pattern, centered around a dark patch with an arm to the north-east; this is the sample holder.\n",
+    "We see a diffuse scattering pattern, centered around a dark patch with an arm to the north-east; this is the beam stop.\n",
     "It is clear that the sample and the beam are not in the center of the panel, which is marked by the black cross"
    ]
   },
@@ -103,7 +103,7 @@
     "\n",
     "Adding a mask, based on the pixel neutron counts (integrated along the `tof` dimension),\n",
     "will yield a circular mask around the beam center.\n",
-    "Because the sample holder is highly absorbent to neutrons, such a mask will also mask out the sample holder,\n",
+    "Because the beam stop is highly absorbent to neutrons, such a mask will also mask out the shadow of the beam stop,\n",
     "making it a very simple but effective way of masking."
    ]
   },
@@ -189,7 +189,7 @@
    "metadata": {},
    "source": [
     "We can now update our previous figure with the new position of the beam center (pink dot),\n",
-    "which is clearly in the center of the beam/sample holder."
+    "which is clearly in the center of the beam stop."
    ]
   },
   {


### PR DESCRIPTION
The current wording in the notebook is probably wrong, it's likely that the shadow in the detector images in the beam center notebook comes from the beam stop and not from the sample holder.

(In fact the earliest version of the notebook in the old ess documentation repo does say the shadow is the beam stop,  but this was changed at some point.)